### PR TITLE
Fix building of e.g., vendor/tree-sitter-haskell-src/scanner.cc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,7 @@ impl TreeSitterParser {
             cpp_build
                 .include(&dir)
                 .cpp(true)
+                .flag("--std=c++14")
                 .flag("-Wno-unused-parameter")
                 .flag("-Wno-ignored-qualifiers");
             for file in cpp_files {


### PR DESCRIPTION
At least this parser uses C++11 (lambda expressions) and C++14 features
(lambda `auto` parameter types). Since the default C++ standard of
compilers can vary, this patch explicitly sets C++14 mode when building
any vendored C++ files.