### PR TITLE
Support `cjs` and `mjs` extensions for JavaScript

### DIFF
--- a/src/tree_sitter_parser.rs
+++ b/src/tree_sitter_parser.rs
@@ -139,7 +139,7 @@ pub fn from_extension(extension: &OsStr) -> Option<TreeSitterConfig> {
             atom_nodes: (vec![]).into_iter().collect(),
             delimiter_tokens: (vec![("(", ")"), ("{", "}")]),
         }),
-        "js" | "jsx" => Some(TreeSitterConfig {
+        "cjs" | "js" | "jsx" | "mjs" => Some(TreeSitterConfig {
             name: "JavaScript",
             language: unsafe { tree_sitter_javascript() },
             atom_nodes: (vec!["string"]).into_iter().collect(),


### PR DESCRIPTION
This PR adds `cjs` and `mjs` to the extensions matched for JavaScript. Node.js uses the [`cjs` and `mjs` extensions][1] to indicate different module systems.

[1]: https://nodejs.org/api/packages.html#packages_determining_module_system