### PR TITLE
Fix "she-bang" typo

### DIFF
--- a/src/guess_language.rs
+++ b/src/guess_language.rs
@@ -254,7 +254,7 @@ mod tests {
     fn test_guess_by_emacs_mode_second_line() {
         let path = Path::new("foo");
         assert_eq!(
-            guess(path, "!#/bin/bash\n; -*- mode: Lisp; -*-"),
+            guess(path, "#!/bin/bash\n; -*- mode: Lisp; -*-"),
             Some(CommonLisp)
         );
     }


### PR DESCRIPTION
This makes the test correct in case the full rule of only recognizing an Emacs mode line on the second line if the first line is a "she-bang" line is ever fully implemented.