### PR TITLE
Fixes suggested by `cargo clippy`

### DIFF
--- a/src/changes.rs
+++ b/src/changes.rs
@@ -11,17 +11,9 @@ pub enum ChangeKind<'a> {
     Novel,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ChangeMap<'a> {
     changes: FxHashMap<NonZeroU32, ChangeKind<'a>>,
-}
-
-impl<'a> Default for ChangeMap<'a> {
-    fn default() -> Self {
-        Self {
-            changes: Default::default(),
-        }
-    }
 }
 
 impl<'a> ChangeMap<'a> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,6 @@
 //! Calculate which nearby lines should also be displayed.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
 use rustc_hash::FxHashSet;
@@ -189,14 +190,14 @@ fn merge_in_opposite_lines(
     for (line, opposite_line) in matched_lines {
         if let Some(opposite_line) = opposite_line {
             while let Some(novel_opposite_line) = novel_opposite_lines.get(i) {
-                if novel_opposite_line < opposite_line {
-                    res.push((None, Some(*novel_opposite_line)));
-                    i += 1;
-                } else if novel_opposite_line == opposite_line {
-                    i += 1;
-                } else {
-                    break;
+                match novel_opposite_line.cmp(opposite_line) {
+                    Ordering::Less => res.push((None, Some(*novel_opposite_line))),
+                    Ordering::Equal => (),
+                    Ordering::Greater => {
+                        break;
+                    }
                 }
+                i += 1;
             }
         }
         res.push((*line, *opposite_line));
@@ -502,7 +503,7 @@ fn after_with_opposites(
                         all_opposites = all_opposites
                             .into_iter()
                             .filter(|x| *x > prev_max_opposite)
-                            .collect()
+                            .collect();
                     }
 
                     all_opposites.first().copied()

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -92,11 +92,9 @@ fn shortest_path(start: Vertex) -> Vec<(Edge, Vertex)> {
                 format!(
                     "{:20} {:20} --- {:3} {:?}",
                     x.1.lhs_syntax
-                        .map(Syntax::dbg_content)
-                        .unwrap_or_else(|| "None".into()),
+                        .map_or_else(|| "None".into(), Syntax::dbg_content),
                     x.1.rhs_syntax
-                        .map(Syntax::dbg_content)
-                        .unwrap_or_else(|| "None".into()),
+                        .map_or_else(|| "None".into(), Syntax::dbg_content),
                     x.0.cost(),
                     x.0,
                 )
@@ -154,7 +152,7 @@ pub fn mark_syntax<'a>(
     let start = Vertex::new(lhs_syntax, rhs_syntax);
     let route = shortest_path(start);
 
-    populate_change_map(&route, change_map)
+    populate_change_map(&route, change_map);
 }
 
 #[cfg(test)]

--- a/src/files.rs
+++ b/src/files.rs
@@ -111,7 +111,7 @@ pub fn relative_paths_in_either(lhs_dir: &Path, rhs_dir: &Path) -> Vec<PathBuf> 
                 if !seen.contains(lhs_path) {
                     // It should be impossible to get duplicates, but
                     // be defensive.
-                    res.push(lhs_path.to_owned());
+                    res.push(lhs_path.clone());
                     seen.insert(lhs_path);
                 }
 
@@ -124,8 +124,8 @@ pub fn relative_paths_in_either(lhs_dir: &Path, rhs_dir: &Path) -> Vec<PathBuf> 
                 } else if seen.contains(rhs_path) {
                     j += 1;
                 } else {
-                    res.push(lhs_path.to_owned());
-                    res.push(rhs_path.to_owned());
+                    res.push(lhs_path.clone());
+                    res.push(rhs_path.clone());
 
                     seen.insert(lhs_path);
                     seen.insert(rhs_path);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -137,10 +137,7 @@ fn push_both_delimiters<'a>(
 }
 
 fn can_pop_either_parent(entered: &Stack<EnteredDelimiter>) -> bool {
-    match entered.peek() {
-        Some(EnteredDelimiter::PopEither(_)) => true,
-        _ => false,
-    }
+    matches!(entered.peek(), Some(EnteredDelimiter::PopEither(_)))
 }
 
 fn try_pop_both<'a>(
@@ -288,7 +285,7 @@ pub enum Edge {
 }
 
 impl Edge {
-    pub fn cost(&self) -> u64 {
+    pub fn cost(self) -> u64 {
         match self {
             // When we're at the end of a list, there's only one exit
             // delimiter possibility, so the cost doesn't matter. We
@@ -302,9 +299,11 @@ impl Edge {
             ExitDelimiterLHS | ExitDelimiterRHS => 2,
 
             // Matching nodes is always best.
-            UnchangedNode { depth_difference } => min(40, *depth_difference as u64 + 1),
+            UnchangedNode { depth_difference } => min(40, u64::from(depth_difference) + 1),
             // Matching an outer delimiter is good.
-            EnterUnchangedDelimiter { depth_difference } => 100 + min(40, *depth_difference as u64),
+            EnterUnchangedDelimiter { depth_difference } => {
+                100 + min(40, u64::from(depth_difference))
+            }
 
             // Replacing a comment is better than treating it as novel.
             ReplacedComment { levenshtein_pct } => 150 + u64::from(100 - levenshtein_pct),
@@ -314,7 +313,7 @@ impl Edge {
             | NovelAtomRHS { contiguous }
             | EnterNovelDelimiterLHS { contiguous }
             | EnterNovelDelimiterRHS { contiguous } => {
-                if *contiguous {
+                if contiguous {
                     300
                 } else {
                     // This needs to be more than 40 greater than the

--- a/src/guess_language.rs
+++ b/src/guess_language.rs
@@ -93,8 +93,7 @@ fn from_emacs_mode_header(src: &str) -> Option<Language> {
     // first line is a shebang.
     for line in src.lines().take(2) {
         let mode_name: String = match (MODE_RE.captures(line), SHORTHAND_RE.captures(line)) {
-            (Some(cap), _) => cap[1].into(),
-            (_, Some(cap)) => cap[1].into(),
+            (Some(cap), _) | (_, Some(cap)) => cap[1].into(),
             _ => "".into(),
         };
         let lang = match mode_name.to_ascii_lowercase().trim().borrow() {

--- a/src/hunks.rs
+++ b/src/hunks.rs
@@ -81,18 +81,14 @@ fn fill_between(
     let mut lhs_lines = vec![];
     if let (Some(prev_lhs), Some(next_lhs)) = (prev_lhs, next_lhs) {
         if prev_lhs.0 + 1 < next_lhs.0 {
-            lhs_lines = (prev_lhs.0 + 1..next_lhs.0)
-                .map(|line| line.into())
-                .collect();
+            lhs_lines = (prev_lhs.0 + 1..next_lhs.0).map(LineNumber::from).collect();
         }
     }
 
     let mut rhs_lines = vec![];
     if let (Some(prev_rhs), Some(next_rhs)) = (prev_rhs, next_rhs) {
         if prev_rhs.0 + 1 < next_rhs.0 {
-            rhs_lines = (prev_rhs.0 + 1..next_rhs.0)
-                .map(|line| line.into())
-                .collect();
+            rhs_lines = (prev_rhs.0 + 1..next_rhs.0).map(LineNumber::from).collect();
         }
     }
 
@@ -345,8 +341,8 @@ fn lines_to_hunks(
     hunks
 }
 
-/// Given a sequence of novel MatchedPos values in a section between
-/// two unchanged MatchedPos values, return them in an order suited
+/// Given a sequence of novel [`MatchedPos`] values in a section between
+/// two unchanged [`MatchedPos`] values, return them in an order suited
 /// for displaying.
 ///
 /// ```text
@@ -404,20 +400,18 @@ fn novel_section_in_order(
     // Next, we want novel MatchedPos values that occur on lines
     // without any unchanged MatchedPos values.
     while let Some(lhs_mp) = lhs_iter.peek() {
-        if !opposite_to_lhs.contains_key(&lhs_mp.pos.line) {
-            res.push((Side::Left, (**lhs_mp).clone()));
-            lhs_iter.next();
-        } else {
+        if opposite_to_lhs.contains_key(&lhs_mp.pos.line) {
             break;
         }
+        res.push((Side::Left, (**lhs_mp).clone()));
+        lhs_iter.next();
     }
     while let Some(rhs_mp) = rhs_iter.peek() {
-        if !opposite_to_rhs.contains_key(&rhs_mp.pos.line) {
-            res.push((Side::Right, (**rhs_mp).clone()));
-            rhs_iter.next();
-        } else {
+        if opposite_to_rhs.contains_key(&rhs_mp.pos.line) {
             break;
         }
+        res.push((Side::Right, (**rhs_mp).clone()));
+        rhs_iter.next();
     }
 
     // Finally, the remainder of the novel MatchedPos values will be
@@ -432,7 +426,7 @@ fn novel_section_in_order(
     res
 }
 
-/// Return a vec of novel MatchedPos values in an order suited for
+/// Return a vec of novel [`MatchedPos`] values in an order suited for
 /// displaying.
 ///
 /// Since novel positions don't have a corresponding opposite
@@ -642,11 +636,11 @@ pub fn matched_lines_for_hunk(
     } else {
         start_i = 0;
     }
-    if end_i + MAX_PADDING < matched_lines.len() {
-        end_i += MAX_PADDING
+    end_i += if end_i + MAX_PADDING < matched_lines.len() {
+        MAX_PADDING
     } else {
-        end_i = matched_lines.len();
-    }
+        matched_lines.len()
+    };
 
     matched_lines[start_i..end_i].to_vec()
 }

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -64,8 +64,6 @@ pub fn print(
         for (lhs_line, _) in before_lines {
             if let Some(lhs_line) = lhs_line {
                 println!("{}   {}", format_line_num(lhs_line), lhs_lines[lhs_line.0]);
-            } else {
-                continue;
             }
         }
 
@@ -76,8 +74,6 @@ pub fn print(
                     format_line_num(*lhs_line).red().bold(),
                     lhs_lines[lhs_line.0]
                 );
-            } else {
-                continue;
             }
         }
         for (_, rhs_line) in &hunk_lines {
@@ -87,16 +83,12 @@ pub fn print(
                     format_line_num(*rhs_line).green().bold(),
                     rhs_lines[rhs_line.0]
                 );
-            } else {
-                continue;
             }
         }
 
         for (_, rhs_line) in &after_lines {
             if let Some(rhs_line) = rhs_line {
                 println!("   {}{}", format_line_num(*rhs_line), rhs_lines[rhs_line.0]);
-            } else {
-                continue;
             }
         }
         println!();

--- a/src/options.rs
+++ b/src/options.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_BYTE_LIMIT: usize = 1_000_000;
 
 const USAGE: &str = concat!(env!("CARGO_BIN_NAME"), " [OPTIONS] OLD-PATH NEW-PATH");
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum ColorOutput {
     Always,
     Auto,
@@ -314,7 +314,7 @@ pub fn parse_args() -> Mode {
 /// Choose the display width: try to autodetect, or fall back to a
 /// sensible default.
 fn detect_display_width() -> usize {
-    term_size::dimensions().map(|(w, _)| w).unwrap_or(80)
+    term_size::dimensions().map_or(80, |(w, _)| w)
 }
 
 pub fn should_use_color(color_output: ColorOutput) -> bool {

--- a/src/sliders.rs
+++ b/src/sliders.rs
@@ -355,8 +355,8 @@ fn slide_to_prev_node<'a>(
         };
 
         insert_deep_novel(before_start_node, change_map);
-        insert_deep_unchanged(last_node, &opposite, change_map);
-        insert_deep_unchanged(&opposite, last_node, change_map);
+        insert_deep_unchanged(last_node, opposite, change_map);
+        insert_deep_unchanged(opposite, last_node, change_map);
     }
 }
 
@@ -404,8 +404,8 @@ fn slide_to_next_node<'a>(
             _ => unreachable!(),
         };
 
-        insert_deep_unchanged(start_node, &opposite, change_map);
-        insert_deep_unchanged(&opposite, start_node, change_map);
+        insert_deep_unchanged(start_node, opposite, change_map);
+        insert_deep_unchanged(opposite, start_node, change_map);
         insert_deep_novel(after_last_node, change_map);
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -19,7 +19,7 @@ pub enum BackgroundColor {
 }
 
 impl BackgroundColor {
-    pub fn is_dark(&self) -> bool {
+    pub fn is_dark(self) -> bool {
         matches!(self, BackgroundColor::Dark)
     }
 }
@@ -230,12 +230,10 @@ pub fn novel_style(style: Style, is_lhs: bool, background: BackgroundColor) -> S
         } else {
             style.bright_green()
         }
+    } else if is_lhs {
+        style.red()
     } else {
-        if is_lhs {
-            style.red()
-        } else {
-            style.green()
-        }
+        style.green()
     }
 }
 
@@ -277,9 +275,7 @@ pub fn color_positions(
                 style = novel_style(style, is_lhs, background);
                 if matches!(
                     highlight,
-                    TokenKind::Delimiter
-                        | TokenKind::Atom(AtomKind::Keyword)
-                        | TokenKind::Atom(AtomKind::Type)
+                    TokenKind::Delimiter | TokenKind::Atom(AtomKind::Keyword | AtomKind::Type)
                 ) {
                     style = style.bold();
                 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -291,8 +291,7 @@ impl<'a> Syntax<'a> {
             } => {
                 let line = position
                     .first()
-                    .map(|p| format!("{}", p.line.one_indexed()))
-                    .unwrap_or_else(|| "?".to_owned());
+                    .map_or_else(|| "?".to_owned(), |p| p.line.one_indexed().to_string());
 
                 format!("{} line:{}", content, line)
             }

--- a/src/unchanged.rs
+++ b/src/unchanged.rs
@@ -7,7 +7,7 @@ const TINY_TREE_THRESHOLD: u32 = 10;
 const MOSTLY_UNCHANGED_MIN_NODES: usize = 4;
 const MOSTLY_UNCHANGED_MIN_COMMON_CHILDREN: usize = 4;
 
-/// Set ChangeKind on nodes that are obviously unchanged, and return a
+/// Set [`ChangeKind`] on nodes that are obviously unchanged, and return a
 /// vec of pairs that need proper diffing.
 pub fn mark_unchanged<'a>(
     lhs_nodes: &[&'a Syntax<'a>],
@@ -328,7 +328,7 @@ fn as_singleton_list_children<'a>(
     ) = (lhs_nodes, rhs_nodes)
     {
         if lhs_open == rhs_open && lhs_close == rhs_close {
-            return Some((lhs_children.to_vec(), rhs_children.to_vec()));
+            return Some((lhs_children.clone(), rhs_children.clone()));
         }
     }
 
@@ -375,7 +375,7 @@ fn shrink_unchanged_delimiters<'a>(
 /// Skip syntax nodes at the beginning or end that are obviously
 /// unchanged.
 ///
-/// Set the ChangeKind on the definitely changed nodes, and return the
+/// Set the [`ChangeKind`] on the definitely changed nodes, and return the
 /// nodes that may contain changes.
 fn shrink_unchanged_at_ends<'a>(
     lhs_nodes: &[&'a Syntax<'a>],


### PR DESCRIPTION
Fixes as suggested by clippy, such as reducing nesting in if-then chains, replacing `!result.is_ok()` with `result.is_err()`, using the `matches!` macro, and matching on the result of `x.cmp(y)` rather than an if-then chain of `if x == y {} else if x < y {} else {}`