### PR TITLE
Add homebrew installation guide in manual

### DIFF
--- a/manual/src/getting_started.md
+++ b/manual/src/getting_started.md
@@ -10,6 +10,17 @@ Packages are also available on the following platforms.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/difftastic.svg)](https://repology.org/project/difftastic/versions)
 
+
+## Installing via homebrew (on macOS or Linux)
+
+Difftastic can be installed with [Homebrew on MacOS](https://brew.sh/) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).
+
+
+```
+$ brew install difftastic
+```
+
+
 ## Installing from source
 
 ### Build Requirements

--- a/manual/src/getting_started.md
+++ b/manual/src/getting_started.md
@@ -13,7 +13,7 @@ Packages are also available on the following platforms.
 
 ## Installing via homebrew (on macOS or Linux)
 
-Difftastic can be installed with [Homebrew on MacOS](https://brew.sh/) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).
+Difftastic can be installed with [Homebrew](https://formulae.brew.sh/formula/difftastic) on macOS or Linux.
 
 
 ```


### PR DESCRIPTION
Hi there, now homebrew supports Difftastic by https://github.com/Homebrew/homebrew-core/pull/98104.

So I've updated the installation guide to include a homebrew section.

Related issue: #201