### PR TITLE
fix: Remove trailing lines before calculating max_lines

### DIFF
--- a/src/lines.rs
+++ b/src/lines.rs
@@ -1,10 +1,8 @@
 //! Manipulate lines of text and groups of lines.
 
 use crate::positions::SingleLineSpan;
-use std::{
-    cmp::{max, Ordering},
-    fmt,
-};
+use std::ops::Sub;
+use std::{cmp::Ordering, fmt};
 
 /// A distinct number type for line numbers, to prevent confusion with
 /// other numerical data.
@@ -165,7 +163,12 @@ pub trait MaxLine {
 
 impl<S: AsRef<str>> MaxLine for S {
     fn max_line(&self) -> LineNumber {
-        (max(1, self.as_ref().trim_end().split('\n').count()) - 1).into()
+        self.as_ref()
+            .trim_end() // Remove extra trailing whitespaces.
+            .split('\n') // Split by `\n` to calculate lines.
+            .count()
+            .sub(1) // Sub 1 to make zero-indexed LineNumber
+            .into()
     }
 }
 

--- a/src/lines.rs
+++ b/src/lines.rs
@@ -165,7 +165,7 @@ pub trait MaxLine {
 
 impl<S: AsRef<str>> MaxLine for S {
     fn max_line(&self) -> LineNumber {
-        (max(1, self.as_ref().split('\n').count()) - 1).into()
+        (max(1, self.as_ref().trim_end().split('\n').count()) - 1).into()
     }
 }
 
@@ -239,7 +239,13 @@ mod tests {
     #[test]
     fn str_max_line_trailing_newline() {
         let line: String = "foo\nbar\n".into();
-        assert_eq!(line.max_line().0, 2);
+        assert_eq!(line.max_line().0, 1);
+    }
+
+    #[test]
+    fn str_max_line_extra_trailing_newline() {
+        let line: String = "foo\nbar\n\n".into();
+        assert_eq!(line.max_line().0, 1);
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

---

Hi, this PR will fix #228 

I have tested on `janet_after.janet` and `ocaml_after.ml`.

But I'm not sure about the side effects of this patch, PTAL.

> BTW, this project is awesome :rocket: 