### PR TITLE
Use background colors to improve diff readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cansi"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185b9281d84fc234662dc95ef999e5ac4e9b7591a6e5aa54edabda3179b80b4f"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,7 @@ name = "difftastic"
 version = "0.29.0"
 dependencies = [
  "atty",
+ "cansi",
  "cc",
  "clap",
  "const_format",
@@ -188,6 +195,7 @@ dependencies = [
  "typed-arena",
  "walkdir",
  "wu-diff",
+ "yansi",
 ]
 
 [[package]]
@@ -593,3 +601,9 @@ name = "wu-diff"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e6735fcde06432870db8dc9d7e3ab1b93727c14eaef329969426299f28893"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ owo-colors = "3.3.0"
 rpds = "0.10.0"
 wu-diff = "0.1.2"
 rayon = "1.5.2"
+yansi = "0.5.1"
+cansi = "2.1.1"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"

--- a/src/side_by_side.rs
+++ b/src/side_by_side.rs
@@ -460,9 +460,8 @@ pub fn print(
                                 // tried several other ANSI stripping libs, this one actually works
                                     - categorise_text(&line_to_print)
                                         .iter()
-                                        .map(|s| s.text)
-                                        .collect::<String>()
-                                        .len(),
+                                        .map(|s| s.end.abs_diff(s.start) as usize)
+                                        .sum::<usize>(),
                             )
                         } else {
                             (Color::Default, 0)
@@ -506,9 +505,8 @@ pub fn print(
                                 // tried several other ANSI stripping libs, this one actually works
                                     - categorise_text(&line_to_print)
                                         .iter()
-                                        .map(|s| s.text)
-                                        .collect::<String>()
-                                        .len(),
+                                        .map(|s| s.end.abs_diff(s.start) as usize)
+                                        .sum::<usize>(),
                             )
                         } else {
                             (Color::Default, 0)

--- a/src/side_by_side.rs
+++ b/src/side_by_side.rs
@@ -1,10 +1,12 @@
 //! Side-by-side (two column) display of diffs.
 
+use cansi::{self, categorise_text};
 use owo_colors::{OwoColorize, Style};
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},
 };
+use yansi::{Color, Paint};
 
 use crate::{
     constants::Side,
@@ -440,14 +442,40 @@ pub fn print(
                 match rhs_line_num {
                     Some(rhs_line_num) => {
                         let rhs_line = &rhs_colored_lines[rhs_line_num.0];
-                        if same_lines {
-                            println!("{}{}", display_rhs_line_num, rhs_line);
+                        let line_to_print = if same_lines {
+                            format!("{}{}", display_rhs_line_num, rhs_line)
                         } else {
-                            println!(
+                            format!(
                                 "{}{}{}",
                                 display_lhs_line_num, display_rhs_line_num, rhs_line
-                            );
-                        }
+                            )
+                        };
+                        let (line_bg, padding_len) = if rhs_lines_with_novel.contains(&rhs_line_num)
+                        {
+                            (
+                                Color::Fixed(194),
+                                display_options.display_width
+                                // we are using cansi::categorize_text to remove ANSI escapes
+                                // if we don't do this, we can't properly pad the line length
+                                // tried several other ANSI stripping libs, this one actually works
+                                    - categorise_text(&line_to_print)
+                                        .iter()
+                                        .map(|s| s.text)
+                                        .collect::<String>()
+                                        .len(),
+                            )
+                        } else {
+                            (Color::Default, 0)
+                        };
+                        println!(
+                            "{}",
+                            Paint::wrapping(format!(
+                                "{}{}",
+                                line_to_print,
+                                " ".repeat(padding_len)
+                            ))
+                            .bg(line_bg)
+                        );
                     }
                     None => {
                         // We didn't have any changed RHS lines in the
@@ -460,17 +488,43 @@ pub fn print(
                 match lhs_line_num {
                     Some(lhs_line_num) => {
                         let lhs_line = &lhs_colored_lines[lhs_line_num.0];
-                        if same_lines {
-                            println!("{}{}", display_lhs_line_num, lhs_line);
+                        let line_to_print = if same_lines {
+                            format!("{}{}", display_lhs_line_num, lhs_line)
                         } else {
-                            println!(
+                            format!(
                                 "{}{}{}",
-                                display_lhs_line_num, display_rhs_line_num, lhs_line
-                            );
-                        }
+                                display_lhs_line_num, display_lhs_line_num, lhs_line
+                            )
+                        };
+                        let (line_bg, padding_len) = if lhs_lines_with_novel.contains(&lhs_line_num)
+                        {
+                            (
+                                Color::Fixed(224),
+                                display_options.display_width
+                                // we are using cansi::categorize_text to remove ANSI escapes
+                                // if we don't do this, we can't properly pad the line length
+                                // tried several other ANSI stripping libs, this one actually works
+                                    - categorise_text(&line_to_print)
+                                        .iter()
+                                        .map(|s| s.text)
+                                        .collect::<String>()
+                                        .len(),
+                            )
+                        } else {
+                            (Color::Default, 0)
+                        };
+                        println!(
+                            "{}",
+                            Paint::wrapping(format!(
+                                "{}{}",
+                                line_to_print,
+                                " ".repeat(padding_len)
+                            ))
+                            .bg(line_bg)
+                        );
                     }
                     None => {
-                        println!("{}{}", display_lhs_line_num, display_rhs_line_num);
+                        println!("{}{}", display_lhs_line_num, display_lhs_line_num);
                     }
                 }
             } else {
@@ -545,7 +599,28 @@ pub fn print(
                         s
                     };
 
-                    println!("{}{}{}{}{}", lhs_num, lhs_line, SPACER, rhs_num, rhs_line);
+                    println!(
+                        "{}{}{}",
+                        Paint::wrapping(format!("{}{}", lhs_num, lhs_line)).bg(
+                            if lhs_line_num.is_some()
+                                && lhs_lines_with_novel.contains(&lhs_line_num.unwrap())
+                            {
+                                Color::Fixed(224)
+                            } else {
+                                Color::Default
+                            }
+                        ),
+                        SPACER,
+                        Paint::wrapping(format!("{}{}", rhs_num, rhs_line)).bg(
+                            if rhs_line_num.is_some()
+                                && rhs_lines_with_novel.contains(&rhs_line_num.unwrap())
+                            {
+                                Color::Fixed(194)
+                            } else {
+                                Color::Default
+                            }
+                        ),
+                    );
                 }
             }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -92,7 +92,7 @@ pub fn split_and_apply(
 ) -> Vec<String> {
     if styles.is_empty() && !line.trim().is_empty() {
         // Missing styles is a bug, so highlight in purple to make this obvious.
-        return split_string_by_codepoint(line, max_len, matches!(side, Side::Left))
+        return split_string_by_codepoint(line, max_len, true)
             .into_iter()
             .map(|part| {
                 if use_color {
@@ -107,7 +107,7 @@ pub fn split_and_apply(
     let mut styled_parts = vec![];
     let mut part_start = 0;
 
-    for part in split_string_by_codepoint(line, max_len, matches!(side, Side::Left)) {
+    for part in split_string_by_codepoint(line, max_len, true) {
         let mut res = String::with_capacity(part.len());
         let mut prev_style_end = 0;
         for (span, style) in styles {
@@ -227,14 +227,14 @@ fn apply(s: &str, styles: &[(SingleLineSpan, Style)]) -> String {
 pub fn novel_style(style: Style, is_lhs: bool, background: BackgroundColor) -> Style {
     if background.is_dark() {
         if is_lhs {
-            style.bright_red()
+            style.on_red()
         } else {
-            style.bright_green()
+            style.on_green()
         }
     } else if is_lhs {
-        style.red()
+        style.on_bright_red()
     } else {
-        style.green()
+        style.on_bright_green()
     }
 }
 


### PR DESCRIPTION
This pull request changes the styling of difftastic output to be closer to [delta](https://github.com/dandavison/delta) and [git-split-diffs](https://github.com/banga/git-split-diffs). Using background colors to show differences is a lot easier to understand when there is syntax highlighting involved.

I have probably missed a few things that need to be addressed before a merge. Please let me know if you see omissions or issues.

<img width="2032" alt="Part of this pull request rendered in the new style." src="https://user-images.githubusercontent.com/80877/168452356-83e67ab3-cfc8-4473-a184-d2266e258427.png">

This addresses issues #167, #265, and #275.