### PR TITLE
use unicode-width to align CJK characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "tree-sitter",
  "tree_magic_mini",
  "typed-arena",
+ "unicode-width",
  "walkdir",
  "wu-diff",
 ]
@@ -625,6 +626,12 @@ name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ wu-diff = "0.1.2"
 rayon = "1.5.2"
 tree_magic_mini = "3.0.3"
 bumpalo = "3.9.1"
+unicode-width = "0.1.9"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/sample_files/chinese_after.po
+++ b/sample_files/chinese_after.po
@@ -1,0 +1,59 @@
+#: ../errors.h:589
+# reorder if possible
+#, fuzzy, c-format
+# msgid "E244: Illegal %s name \"%s\" in font name \"%s\""
+# msgstr "E244: 字体名 \"%3$s\" 中有非法 %1$s 名称 \"%2$s\""
+
+#: ../errors.h:591
+#, c-format
+msgid "E245: Illegal char '%c' in font name \"%s\""
+msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
+
+#: ../errors.h:594
+msgid "E246: FileChangedShell autocommand deleted buffer"
+msgstr "E246: FileChangedShell 自动命令删除了缓冲区"
+
+#: ../errors.h:597
+#, c-format
+msgid "E247: No registered server named \"%s\""
+msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
+
+#: ../errors.h:788
+# reorder if possible
+#, fuzzy, c-format
+# msgid "E316: ml_get: Cannot find line %ld in buffer %d %s"
+# msgstr "E316: ml_get: 在缓冲区 %2$d %3$s 中找不到第 %1$ld 行"
+
+#: ../errors.h:790
+msgid "E317: Pointer block id wrong"
+msgstr "E317: 指针块 id 错误"
+
+#: ../errors.h:792
+msgid "E317: Pointer block id wrong 2"
+msgstr "E317: 指针块 id 错误 2"
+
+#: ../errors.h:794
+msgid "E317: Pointer block id wrong 3"
+msgstr "E317: 指针块 id 错误 3"
+
+#: ../errors.h:796
+msgid "E317: Pointer block id wrong 4"
+msgstr "E317: 指针块 id 错误 4"
+
+#: ../errors.h:2705
+# reorder if possible
+#, fuzzy, c-format
+# msgid "E1037: Cannot use \"%s\" with %s"
+# msgstr "E1037: 不能对 %2$s 使用 \"%1$s\""
+
+#: ../errors.h:2707
+msgid "E1038: \"vim9script\" can only be used in a script"
+msgstr "E1038: \"vim9script\" 只能在脚本中使用"
+
+#: ../errors.h:2709
+msgid "E1039: \"vim9script\" must be the first command in a script"
+msgstr "E1039: \"vim9script\" 必须是脚本中的第一条命令"
+
+#: ../errors.h:2712
+msgid "E1040: Cannot use :scriptversion after :vim9script"
+msgstr "E1040: :vim9script 之后不能使用 :scriptversion"

--- a/sample_files/chinese_before.po
+++ b/sample_files/chinese_before.po
@@ -1,0 +1,59 @@
+#: ../errors.h:589
+# reorder if possible
+#, fuzzy, c-format
+msgid "E244: Illegal %s name \"%s\" in font name \"%s\""
+msgstr "E244: 字体名 \"%3$s\" 中有非法 %1$s 名称 \"%2$s\""
+
+#: ../errors.h:591
+#, c-format
+msgid "E245: Illegal char '%c' in font name \"%s\""
+msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
+
+#: ../errors.h:594
+msgid "E246: FileChangedShell autocommand deleted buffer"
+msgstr "E246: FileChangedShell 自动命令删除了缓冲区"
+
+#: ../errors.h:597
+#, c-format
+msgid "E247: No registered server named \"%s\""
+msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
+
+#: ../errors.h:788
+# reorder if possible
+#, fuzzy, c-format
+msgid "E316: ml_get: Cannot find line %ld in buffer %d %s"
+msgstr "E316: ml_get: 在缓冲区 %2$d %3$s 中找不到第 %1$ld 行"
+
+#: ../errors.h:790
+msgid "E317: Pointer block id wrong"
+msgstr "E317: 指针块 id 错误"
+
+#: ../errors.h:792
+msgid "E317: Pointer block id wrong 2"
+msgstr "E317: 指针块 id 错误 2"
+
+#: ../errors.h:794
+msgid "E317: Pointer block id wrong 3"
+msgstr "E317: 指针块 id 错误 3"
+
+#: ../errors.h:796
+msgid "E317: Pointer block id wrong 4"
+msgstr "E317: 指针块 id 错误 4"
+
+#: ../errors.h:2705
+# reorder if possible
+#, fuzzy, c-format
+msgid "E1037: Cannot use \"%s\" with %s"
+msgstr "E1037: 不能对 %2$s 使用 \"%1$s\""
+
+#: ../errors.h:2707
+msgid "E1038: \"vim9script\" can only be used in a script"
+msgstr "E1038: \"vim9script\" 只能在脚本中使用"
+
+#: ../errors.h:2709
+msgid "E1039: \"vim9script\" must be the first command in a script"
+msgstr "E1039: \"vim9script\" 必须是脚本中的第一条命令"
+
+#: ../errors.h:2712
+msgid "E1040: Cannot use :scriptversion after :vim9script"
+msgstr "E1040: :vim9script 之后不能使用 :scriptversion"

--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -7,11 +7,14 @@ sample_files/bad_combine_before.rs sample_files/bad_combine_after.rs
 sample_files/change_outer_before.el sample_files/change_outer_after.el
 1857b63ba1bfa0ccc0a4243db6b1c5c2  -
 
+sample_files/chinese_before.po sample_files/chinese_after.po
+56f0af341fd86727dbac522293e8e013  -
+
 sample_files/clojure_before.clj sample_files/clojure_after.clj
 b916e224f289888252cd7597bab339e6  -
 
 sample_files/comments_before.rs sample_files/comments_after.rs
-f7b56285b9db37d84405f647fb15412f  -
+0b2756c60659993310f899b131cca84f  -
 
 sample_files/context_before.rs sample_files/context_after.rs
 ef267b3bbea4b56a111427a11b24cc6a  -
@@ -62,7 +65,7 @@ sample_files/janet_before.janet sample_files/janet_after.janet
 677604a16ef62f6b6252d76d76e86265  -
 
 sample_files/java_before.java sample_files/java_after.java
-22c27b91fd67d2b894de9a620bcf5c35  -
+d7cdb754cc9311e39c7aa402a8c51ab9  -
 
 sample_files/javascript_before.js sample_files/javascript_after.js
 f4bfe92df94f89942bacc73e4a9db882  -
@@ -158,7 +161,7 @@ sample_files/text_before.txt sample_files/text_after.txt
 dfc3495b8d5931029b479f0c878a3219  -
 
 sample_files/todomvc_before.gleam sample_files/todomvc_after.gleam
-c1d8b44875121d81c583dd3a8fb43232  -
+6f2f2b3905fbff7e283a2d3b312dc658  -
 
 sample_files/toml_before.toml sample_files/toml_after.toml
 1e2de7235c339b07a0784498453e896c  -

--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -521,7 +521,7 @@ pub fn print(
                             display_options.use_color,
                         );
                         if let Some(line_num) = lhs_line_num {
-                            if lhs_lines_with_novel.contains(&line_num) {
+                            if display_options.use_color && lhs_lines_with_novel.contains(&line_num) {
                                 s = if display_options.background_color.is_dark() {
                                     s.bright_red().to_string()
                                 } else {
@@ -542,7 +542,7 @@ pub fn print(
                             display_options.use_color,
                         );
                         if let Some(line_num) = rhs_line_num {
-                            if rhs_lines_with_novel.contains(&line_num) {
+                            if display_options.use_color && rhs_lines_with_novel.contains(&line_num) {
                                 s = if display_options.background_color.is_dark() {
                                     s.bright_green().to_string()
                                 } else {


### PR DESCRIPTION
This corrects this

![difft-bad](https://user-images.githubusercontent.com/440661/175817604-9e0ad035-01d6-4ae1-8294-99f6dfef6512.png)

into this

![difft-good](https://user-images.githubusercontent.com/440661/175817627-c91fd602-b11c-41eb-8569-9a4dbf560dd4.png)

It also fixes when line continuation number columns are colored when redirected to a file / pipe.

This closes #247.