### PR TITLE
updates to support building on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,13 +22,6 @@ impl TreeSitterParser {
             }
         }
 
-        let mut build = cc::Build::new();
-        build.include(&dir).warnings(false); // ignore unused parameter warnings
-        for file in c_files {
-            build.file(dir.join(file));
-        }
-        build.compile(self.name);
-
         if !cpp_files.is_empty() {
             let mut cpp_build = cc::Build::new();
             cpp_build
@@ -58,6 +51,13 @@ impl TreeSitterParser {
             }
             cpp_build.compile(&format!("{}-cpp", self.name));
         }
+
+        let mut build = cc::Build::new();
+        build.include(&dir).warnings(false); // ignore unused parameter warnings
+        for file in c_files {
+            build.file(dir.join(file));
+        }
+        build.compile(self.name);
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.56"
+channel = "1.57"
 components = ["rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
closes #253 thanks to @petrochenkov's fix mentioned there.

I just switched the order of a few lines. I did not change any in the build.rs.
The rust-toolchain.toml had to be updated to support this crate which won't compile in 1.56.1 any longer.
```
Caused by:
  package `os_str_bytes v6.2.0` cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.1
```