### PR TITLE
Fix: Can't build on Windows in a locale whose default encoding is not UTF-8

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,9 @@ impl TreeSitterParser {
         }
 
         let mut build = cc::Build::new();
+        if cfg!(windows) {
+            build.flag("/utf-8");
+        }
         build.include(&dir).warnings(false); // ignore unused parameter warnings
         for file in c_files {
             build.file(dir.join(file));


### PR DESCRIPTION
Fix https://github.com/Wilfred/difftastic/issues/342 by adding `/utf-8` flag to cl.exe.

Ref. https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170