### PR TITLE
Unset LC_ALL and LC_COLLATE to stabilize regression test output

### DIFF
--- a/sample_files/compare_all.sh
+++ b/sample_files/compare_all.sh
@@ -20,6 +20,7 @@ cargo build --release
 # Set language so we expand globs in a consistent order regardless of
 # locale (e.g. on GitHub actions).
 LANG=en_US.UTF-8
+unset LC_ALL LC_COLLATE
 
 echo "==> Check outputs"
 for before_f in sample_files/*before.*; do


### PR DESCRIPTION
I set LC_COLLATE=C in ~/.profile, which appears to change the glob order. LC_ALL would also affect that, so let's unset both.