### PR TITLE
Some optimizations (cont)

### DIFF
--- a/src/diff/dijkstra.rs
+++ b/src/diff/dijkstra.rs
@@ -219,9 +219,9 @@ pub fn mark_syntax<'a>(
             .map(|x| {
                 format!(
                     "{:20} {:20} --- {:3} {:?}",
-                    x.1.lhs_syntax
+                    x.1.lhs_syntax.get_ref()
                         .map_or_else(|| "None".into(), Syntax::dbg_content),
-                    x.1.rhs_syntax
+                    x.1.rhs_syntax.get_ref()
                         .map_or_else(|| "None".into(), Syntax::dbg_content),
                     x.0.cost(),
                     x.0,

--- a/src/diff/dijkstra.rs
+++ b/src/diff/dijkstra.rs
@@ -43,17 +43,12 @@ fn shortest_vertex_path<'a, 'b>(
                 set_neighbours(current, vertex_arena, &mut seen);
 
                 if let Some(neighbors) = &*current.neighbours.borrow() {
-                    for neighbour in neighbors {
-                        let (edge, next) = neighbour;
+                    for &(edge, next) in neighbors {
                         let distance_to_next = distance + edge.cost();
 
-                        let found_shorter_route = match next.predecessor.get() {
-                            Some((prev_shortest, _)) => distance_to_next < prev_shortest,
-                            None => true,
-                        };
-
-                        if found_shorter_route {
-                            next.predecessor.replace(Some((distance_to_next, current)));
+                        if distance_to_next < next.shortest_distance.get() {
+                            next.shortest_distance.set(distance_to_next);
+                            next.predecessor.replace(Some(current));
                             heap.push(Reverse(distance_to_next), next);
                         }
                     }
@@ -74,9 +69,9 @@ fn shortest_vertex_path<'a, 'b>(
         heap.len(),
     );
 
-    let mut current = Some((0, end));
+    let mut current = Some(end);
     let mut vertex_route: Vec<&'b Vertex<'a, 'b>> = vec![];
-    while let Some((_, node)) = current {
+    while let Some(node) = current {
         vertex_route.push(node);
         current = node.predecessor.get();
     }

--- a/src/diff/graph.rs
+++ b/src/diff/graph.rs
@@ -211,44 +211,24 @@ fn push_lhs_delimiter<'a>(
     entered: &Stack<EnteredDelimiter<'a>>,
     delimiter: &'a Syntax<'a>,
 ) -> Stack<EnteredDelimiter<'a>> {
-    let mut modifying_head = false;
-    let (mut lhs_delims, rhs_delims) = match entered.peek() {
-        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => {
-            modifying_head = true;
-            (lhs_delims.clone(), rhs_delims.clone())
-        }
-        _ => (Stack::new(), Stack::new()),
-    };
-    lhs_delims = lhs_delims.push(delimiter);
-
-    let entered = if modifying_head {
-        entered.pop().unwrap()
-    } else {
-        entered.clone()
-    };
-    entered.push(EnteredDelimiter::PopEither((lhs_delims, rhs_delims)))
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => entered.pop().unwrap().push(
+            EnteredDelimiter::PopEither((lhs_delims.push(delimiter), rhs_delims.clone())),
+        ),
+        _ => entered.push(EnteredDelimiter::PopEither((Stack::new().push(delimiter), Stack::new()))),
+    }
 }
 
 fn push_rhs_delimiter<'a>(
     entered: &Stack<EnteredDelimiter<'a>>,
     delimiter: &'a Syntax<'a>,
 ) -> Stack<EnteredDelimiter<'a>> {
-    let mut modifying_head = false;
-    let (lhs_delims, mut rhs_delims) = match entered.peek() {
-        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => {
-            modifying_head = true;
-            (lhs_delims.clone(), rhs_delims.clone())
-        }
-        _ => (Stack::new(), Stack::new()),
-    };
-    rhs_delims = rhs_delims.push(delimiter);
-
-    let entered = if modifying_head {
-        entered.pop().unwrap()
-    } else {
-        entered.clone()
-    };
-    entered.push(EnteredDelimiter::PopEither((lhs_delims, rhs_delims)))
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => entered.pop().unwrap().push(
+            EnteredDelimiter::PopEither((lhs_delims.clone(), rhs_delims.push(delimiter))),
+        ),
+        _ => entered.push(EnteredDelimiter::PopEither((Stack::new(), Stack::new().push(delimiter)))),
+    }
 }
 
 impl<'a, 'b> Vertex<'a, 'b> {

--- a/src/diff/graph.rs
+++ b/src/diff/graph.rs
@@ -114,7 +114,8 @@ fn next_child_syntax<'a>(syntax: &'a Syntax<'a>, children: &[&'a Syntax<'a>]) ->
 #[derive(Debug, Clone, Eq)]
 pub struct Vertex<'a, 'b> {
     pub neighbours: RefCell<Option<Vec<(Edge, &'b Vertex<'a, 'b>)>>>,
-    pub predecessor: Cell<Option<(u64, &'b Vertex<'a, 'b>)>>,
+    pub shortest_distance: Cell<u64>,
+    pub predecessor: Cell<Option<&'b Vertex<'a, 'b>>>,
     pub lhs_syntax: SyntaxRefOrId<'a>,
     pub rhs_syntax: SyntaxRefOrId<'a>,
     parents: Stack<EnteredDelimiter<'a>>,
@@ -129,6 +130,7 @@ impl<'a, 'b> Vertex<'a, 'b> {
         let parents = Stack::new();
         Vertex {
             neighbours: RefCell::new(None),
+            shortest_distance: Cell::new(u64::MAX),
             predecessor: Cell::new(None),
             lhs_syntax: lhs_syntax.map_or(None.into(), |s| s.into()),
             rhs_syntax: rhs_syntax.map_or(None.into(), |s| s.into()),

--- a/src/diff/graph.rs
+++ b/src/diff/graph.rs
@@ -467,14 +467,13 @@ fn looks_like_punctuation(content: &str) -> bool {
 
 /// Compute the neighbours of `v` if we haven't previously done so,
 /// write them to the .neighbours cell inside `v`, and return them.
-pub fn get_set_neighbours<'syn, 'b>(
+pub fn set_neighbours<'syn, 'b>(
     v: &Vertex<'syn, 'b>,
     alloc: &'b Bump,
     seen: &mut FxHashMap<&Vertex<'syn, 'b>, Vec<&'b Vertex<'syn, 'b>>>,
-) -> Vec<(Edge, &'b Vertex<'syn, 'b>)> {
-    match &*v.neighbours.borrow() {
-        Some(neighbours) => return neighbours.clone(),
-        None => {}
+) {
+    if v.neighbours.borrow().is_some() {
+        return;
     }
 
     let mut res: Vec<(Edge, &Vertex)> = vec![];
@@ -734,8 +733,7 @@ pub fn get_set_neighbours<'syn, 'b>(
         "Must always find some next steps if node is not the end"
     );
 
-    v.neighbours.replace(Some(res.clone()));
-    res
+    v.neighbours.replace(Some(res));
 }
 
 pub fn populate_change_map<'a, 'b>(


### PR DESCRIPTION
This time I tried some radical optimizations.

### Benchmark Approach

To make the result more accurate, I updated my benchmark approach. Here's the command:

```zsh
cargo build --release &&
with-bench hyperfine --warmup=3 "$(echo ~/.cargo/target/release/difft sample_files/slow_{before,after}.rs)" &&
with-bench perf stat ~/.cargo/target/release/difft sample_files/slow_{before,after}.rs > /dev/null &&
time ~/.cargo/target/release/difft sample_files/slow_{before,after}.rs > /dev/null
```

where `with-bench` is a simple Zsh function that fixes CPU frequency and disables boost:

```zsh
_bench-start() {
    sudo cpupower frequency-set -u 3.6G -d 3.6G >/dev/null
    sudo sh -c 'echo 0 > /sys/devices/system/cpu/cpufreq/boost'
    echo '>>>>> BENCH START' >&2
}
_bench-end() {
    sudo cpupower frequency-set -u 10G -d 0.1G >/dev/null
    sudo sh -c 'echo 1 > /sys/devices/system/cpu/cpufreq/boost'
    echo '>>>>> BENCH END' >&2
}
with-bench() {
    _bench-start
    trap '_bench-end' EXIT INT
    $@
}
```

Note that this time `difft` is directly invoked instead of through `cargo run`, so the speedup percentage will be higher (`cargo run` has a fixed extra cost).

### Benchmark Results

Before my first PR:

```text
>>>>> BENCH START
Benchmark 1: /home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs
  Time (mean ± σ):      1.120 s ±  0.032 s    [User: 1.080 s, System: 0.039 s]
  Range (min … max):    1.058 s …  1.169 s    10 runs
 
>>>>> BENCH END
>>>>> BENCH START

 Performance counter stats for '/home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs':

          1,113.87 msec task-clock:u              #    0.998 CPUs utilized          
                 0      context-switches:u        #    0.000 /sec                   
                 0      cpu-migrations:u          #    0.000 /sec                   
             1,423      page-faults:u             #    1.278 K/sec                  
     3,844,769,039      cycles:u                  #    3.452 GHz                    
       319,285,519      stalled-cycles-frontend:u #    8.30% frontend cycles idle   
     1,172,227,367      stalled-cycles-backend:u  #   30.49% backend cycles idle    
     4,498,772,345      instructions:u            #    1.17  insn per cycle         
                                                  #    0.26  stalled cycles per insn
       887,538,102      branches:u                #  796.804 M/sec                  
        19,835,182      branch-misses:u           #    2.23% of all branches        

       1.116052704 seconds time elapsed

       1.062544000 seconds user
       0.049941000 seconds sys


>>>>> BENCH END
~/.cargo/target/release/difft sample_files/slow_{before,after}.rs > /dev/null   1.03s  user 0.05s system 99% cpu 1.077 total
avg shared (code):         0 KB
avg unshared (data/stack): 0 KB
total (sum):               0 KB
max memory:                549 KB
page faults from disk:     0
other page faults:         1490
```

Before my second PR:

```text
>>>>> BENCH START
Benchmark 1: /home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs
  Time (mean ± σ):     829.9 ms ±  15.8 ms    [User: 798.4 ms, System: 30.5 ms]
  Range (min … max):   811.7 ms … 864.5 ms    10 runs
 
>>>>> BENCH END
>>>>> BENCH START

 Performance counter stats for '/home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs':

            824.10 msec task-clock:u              #    1.000 CPUs utilized          
                 0      context-switches:u        #    0.000 /sec                   
                 0      cpu-migrations:u          #    0.000 /sec                   
             1,361      page-faults:u             #    1.652 K/sec                  
     2,838,969,066      cycles:u                  #    3.445 GHz                    
        49,902,292      stalled-cycles-frontend:u #    1.76% frontend cycles idle   
     1,171,930,117      stalled-cycles-backend:u  #   41.28% backend cycles idle    
     3,511,062,625      instructions:u            #    1.24  insn per cycle         
                                                  #    0.33  stalled cycles per insn
       663,773,868      branches:u                #  805.457 M/sec                  
        18,248,650      branch-misses:u           #    2.75% of all branches        

       0.824474162 seconds time elapsed

       0.787025000 seconds user
       0.036682000 seconds sys


>>>>> BENCH END
~/.cargo/target/release/difft sample_files/slow_{before,after}.rs > /dev/null   0.68s  user 0.04s system 99% cpu 0.726 total
avg shared (code):         0 KB
avg unshared (data/stack): 0 KB
total (sum):               0 KB
max memory:                435 KB
page faults from disk:     0
other page faults:         1430
```

Now:

```text
>>>>> BENCH START
Benchmark 1: /home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs
  Time (mean ± σ):     636.9 ms ±   7.4 ms    [User: 596.3 ms, System: 38.8 ms]
  Range (min … max):   629.2 ms … 655.3 ms    10 runs
 
>>>>> BENCH END
>>>>> BENCH START

 Performance counter stats for '/home/qc/.cargo/target/release/difft sample_files/slow_before.rs sample_files/slow_after.rs':

            623.62 msec task-clock:u              #    0.999 CPUs utilized          
                 0      context-switches:u        #    0.000 /sec                   
                 0      cpu-migrations:u          #    0.000 /sec                   
             1,348      page-faults:u             #    2.162 K/sec                  
     2,122,551,842      cycles:u                  #    3.404 GHz                    
        38,713,265      stalled-cycles-frontend:u #    1.82% frontend cycles idle   
       776,217,583      stalled-cycles-backend:u  #   36.57% backend cycles idle    
     2,669,241,946      instructions:u            #    1.26  insn per cycle         
                                                  #    0.29  stalled cycles per insn
       510,784,798      branches:u                #  819.070 M/sec                  
        15,456,464      branch-misses:u           #    3.03% of all branches        

       0.623958630 seconds time elapsed

       0.596642000 seconds user
       0.026663000 seconds sys


>>>>> BENCH END
~/.cargo/target/release/difft sample_files/slow_{before,after}.rs > /dev/null   0.51s  user 0.05s system 99% cpu 0.553 total
avg shared (code):         0 KB
avg unshared (data/stack): 0 KB
total (sum):               0 KB
max memory:                409 KB
page faults from disk:     0
other page faults:         1417
```

### Conclusion

**Speed**: 100% -> 135% -> 176% (according to hyperfine)

**Memory**: 100% -> 79% -> 74%

### Caveats

- In commit [Eliminate some vec clones](https://github.com/QuarticCat/difftastic/commit/827e26d2fc0077ceb359a191ae946592482e0e59), the memory usage abnormally increased, which was not in line with my expectation. I haven't figured out why.

- In commit [Change a RefCell in Vertex to UnsafeCell](https://github.com/QuarticCat/difftastic/commit/9c551abe6876a1514d6505076257faa7ffe1e2db), a lot of unsafe code is applied, and they are apparently out of the boundary that they should stay. I don't know how to design abstractions for them.

- In commit [Refactor seen map](https://github.com/QuarticCat/difftastic/commit/7d36c5f807e9bf361f77a2ac0cdccca63ae7bf1d), I don't understand why your original code was written in this way. I just faithfully convert your code into a faster one.