### PR TITLE
Show function context for diff hunks.

### DIFF
--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -1,8 +1,8 @@
 sample_files/b2_math_before.h sample_files/b2_math_after.h
-637e91c1528894ec0529bc845ef79c88  -
+c6f9abe36eaa0aa479fb19154412fabd  -
 
 sample_files/bad_combine_before.rs sample_files/bad_combine_after.rs
-9f61f6c7e485a2726685f718fef1f9bd  -
+b6f33ef261686a8305335b302356e4c5  -
 
 sample_files/change_outer_before.el sample_files/change_outer_after.el
 1857b63ba1bfa0ccc0a4243db6b1c5c2  -
@@ -20,7 +20,7 @@ sample_files/comments_before.rs sample_files/comments_after.rs
 a736fef589c0bb8b44c83907eb3268df  -
 
 sample_files/context_before.rs sample_files/context_after.rs
-ef267b3bbea4b56a111427a11b24cc6a  -
+048f0d6354d4517b7f9980ad716dc751  -
 
 sample_files/contiguous_before.js sample_files/contiguous_after.js
 9d7bc73c3551064e67f40155abc84798  -
@@ -155,7 +155,7 @@ sample_files/scala_before.scala sample_files/scala_after.scala
 bb18213033492a633e7f978ab9711ae1  -
 
 sample_files/Session_before.kt sample_files/Session_after.kt
-46994b58bb24200f82866951013f03ce  -
+b160640b6e8620950eaba0f617470032  -
 
 sample_files/simple_before.js sample_files/simple_after.js
 b1fe2c184a9a358e314e21aabb0f3cb7  -
@@ -167,10 +167,10 @@ sample_files/slider_at_end_before.json sample_files/slider_at_end_after.json
 1d6162aab8e59c4422e9c14f09ceac3e  -
 
 sample_files/slider_before.rs sample_files/slider_after.rs
-50e1df5af0bf4a1fa7211e079196f1a9  -
+cd0850c88fbf0e5d726af694108ac3c7  -
 
 sample_files/slow_before.rs sample_files/slow_after.rs
-b3f323569ae05e1185810da31c1db31a  -
+c624cd9e2ec8d588f555aa61ad340c14  -
 
 sample_files/small_before.js sample_files/small_after.js
 27bcac13aa17141718a3e6b8c0ac8f47  -

--- a/src/diff/sliders.rs
+++ b/src/diff/sliders.rs
@@ -719,8 +719,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs = parse(&arena, "A B", &config);
-        let rhs = parse(&arena, "A B X\n A B", &config);
+        let (lhs, _lhs_tree) = parse(&arena, "A B", &config);
+        let (rhs, _rhs_tree) = parse(&arena, "A B X\n A B", &config);
         init_all_info(&lhs, &rhs);
 
         let mut change_map = ChangeMap::default();

--- a/src/diff/unchanged.rs
+++ b/src/diff/unchanged.rs
@@ -455,8 +455,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "unchanged A B", &config);
-        let rhs_nodes = parse(&arena, "unchanged X", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "unchanged A B", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "unchanged X", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -481,8 +481,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "A B unchanged", &config);
-        let rhs_nodes = parse(&arena, "X unchanged", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "A B unchanged", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "X unchanged", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -507,8 +507,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "unchanged-before (more-unchanged (A))", &config);
-        let rhs_nodes = parse(&arena, "unchanged-before (more-unchanged (B))", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "unchanged-before (more-unchanged (A))", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "unchanged-before (more-unchanged (B))", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -533,8 +533,8 @@ mod tests {
         let config = from_language(guess_language::Language::EmacsLisp);
 
         // Make sure that the initial unchanged node exceeds TINY_TREE_THRESHOLD.
-        let lhs_nodes = parse(&arena, "(unchanged (1 2 3 4 5 6 7 8 9 10)) A B", &config);
-        let rhs_nodes = parse(&arena, "(unchanged (1 2 3 4 5 6 7 8 9 10)) X", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "(unchanged (1 2 3 4 5 6 7 8 9 10)) A B", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "(unchanged (1 2 3 4 5 6 7 8 9 10)) X", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -561,8 +561,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "A B (unchanged (1 2 3 4 5 6 7 8 9 10))", &config);
-        let rhs_nodes = parse(&arena, "X (unchanged (1 2 3 4 5 6 7 8 9 10))", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "A B (unchanged (1 2 3 4 5 6 7 8 9 10))", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "X (unchanged (1 2 3 4 5 6 7 8 9 10))", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -589,8 +589,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "(A)", &config);
-        let rhs_nodes = parse(&arena, "(B)", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "(A)", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "(B)", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         let mut change_map = ChangeMap::default();
@@ -616,12 +616,12 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(
+        let (lhs_nodes, _lhs_tree) = parse(
             &arena,
             "novel-lhs (unchanged (1 2 3 4 5 6 7 8 9 10)) novel-lhs-2",
             &config,
         );
-        let rhs_nodes = parse(
+        let (rhs_nodes, _rhs_tree) = parse(
             &arena,
             "novel-rhs (unchanged (1 2 3 4 5 6 7 8 9 10)) novel-rhs-2",
             &config,
@@ -653,12 +653,12 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(
+        let (lhs_nodes, _lhs_tree) = parse(
             &arena,
             "novel-lhs (unchanged-1 (1 2 3 4 5 6 7 8 9 10)) (unchanged-2 (1 2 3 4 5 6 7 8 9 10)) novel-lhs-2",
             &config,
         );
-        let rhs_nodes = parse(
+        let (rhs_nodes, _rhs_tree) = parse(
             &arena,
             "novel-rhs (unchanged-1 (1 2 3 4 5 6 7 8 9 10)) (unchanged-2 (1 2 3 4 5 6 7 8 9 10)) novel-rhs-2",
             &config,
@@ -681,12 +681,12 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(
+        let (lhs_nodes, _lhs_tree) = parse(
             &arena,
             "(novel-lhs-before (1 2 3 4 5 6 7 8 9 10) novel-lhs-after)",
             &config,
         );
-        let rhs_nodes = parse(
+        let (rhs_nodes, _rhs_tree) = parse(
             &arena,
             "(novel-rhs-before (1 2 3 4 5 6 7 8 9 10) novel-rhs-after)",
             &config,
@@ -708,12 +708,12 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(
+        let (lhs_nodes, _lhs_tree) = parse(
             &arena,
             "(1 2 3 4 5 6 7 8 9 10) (91 92 93 94 95 96 97 98 99 100)",
             &config,
         );
-        let rhs_nodes = parse(
+        let (rhs_nodes, _rhs_tree) = parse(
             &arena,
             "(1 2 3 4 5 novel-1 6 7 8 9 10) (91 92 93 94 95 novel-2 96 97 98 99 100)",
             &config,
@@ -734,12 +734,12 @@ mod tests {
         //
         // 1: shared-1
         // 2: (shared-2a shared-2b)
-        let lhs_nodes = parse(
+        let (lhs_nodes, _lhs_tree) = parse(
             &arena,
             "(shared-1 (shared-2a shared-2b) not-unique not-unique)",
             &config,
         );
-        let rhs_nodes = parse(
+        let (rhs_nodes, _rhs_tree) = parse(
             &arena,
             "(shared-1 (shared-2a shared-2b) not-unique)",
             &config,
@@ -754,8 +754,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "((novel-lhs 1 2 3 4 5)) x", &config);
-        let rhs_nodes = parse(&arena, "((novel-rhs 1 2 3 4 5)) y", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "((novel-lhs 1 2 3 4 5)) x", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "((novel-rhs 1 2 3 4 5)) y", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         assert_eq!(
@@ -768,8 +768,8 @@ mod tests {
         let arena = Arena::new();
         let config = from_language(guess_language::Language::EmacsLisp);
 
-        let lhs_nodes = parse(&arena, "(novel-lhs 1 2 3 4 5) x", &config);
-        let rhs_nodes = parse(&arena, "[novel-rhs 1 2 3 4 5] y", &config);
+        let (lhs_nodes, _lhs_tree) = parse(&arena, "(novel-lhs 1 2 3 4 5) x", &config);
+        let (rhs_nodes, _rhs_tree) = parse(&arena, "[novel-rhs 1 2 3 4 5] y", &config);
         init_all_info(&lhs_nodes, &rhs_nodes);
 
         assert_eq!(

--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -66,6 +66,7 @@ pub fn print(
                 i + 1,
                 hunks.len(),
                 lang_name,
+                &None,
                 display_options
             )
         );

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -19,4 +19,6 @@ pub struct DiffResult {
     pub rhs_src: FileContent,
     pub lhs_positions: Vec<MatchedPos>,
     pub rhs_positions: Vec<MatchedPos>,
+    pub lhs_tree: Option<tree_sitter::Tree>,
+    pub rhs_tree: Option<tree_sitter::Tree>,
 }


### PR DESCRIPTION
This fixes a difftastic shortcoming relative to “git diff” (or GNU diff's -p, --show-c-function); it shows the context for a given hunk (which function it is in, assuming it actually starts in one). Based on practical testing, it seems to work well with at least Rust, C, C++, Kotlin, Python and Swift, but probably also for more languages.

Unlike git diff and GNU diff, it does not get confused by the function definition being split over multiple lines, since it uses the tree-sitter grammar to find out what is a function definition, which should be much more robust than the textual heuristics diff uses.

There are a number of shortcomings:

 - Context is currently only available in side-by-side mode, not inline.
 - The source code is re-parsed using tree-sitter at display time; we could probably reuse the tree from before it was converted into Difftastic's syntax tree, at the expense of holding onto more RAM during the diffing.
 - If the context is not the same on both sides, difftastic won't try to show both, but instead show the language name as before. The typical failure case for this is if the function changed name or function arguments between the two versions.
 - Certain language grammars, such as Julia and elisp, don't have a clear node that delineates the function body from the name and arguments, which will cause the entire function definition to be treated as the context (which thus usually means it won't be shown at all; see the previous point).
 - The joining of tokens across newlines can cause somewhat unidiomatic whitespace to be added, such as fn foo( arg) instead of fn foo(arg) if “arg” is on a separate line.

Despite all of this, it seems to work very well in practice, from practical experience during real development over a couple of days.

Fixes #304.