### PR TITLE
Support parsing of sub-languages

### DIFF
--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -62,7 +62,7 @@ sample_files/helpful-unit-test-before.el sample_files/helpful-unit-test-after.el
 79597af48ff80bcf9f5d02d20c51606d  -
 
 sample_files/html_before.html sample_files/html_after.html
-5bf6a3d864706e18932c8cd027cb4c0b  -
+baf2ef8bffad85273b97d7ae41d67e0e  -
 
 sample_files/html_simple_before.html sample_files/html_simple_after.html
 2c5a14df5b793bc136e37f263733b26f  -

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -1,5 +1,6 @@
 //! Load and configure parsers written with tree-sitter.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use crate::parse::guess_language as guess;
@@ -10,6 +11,21 @@ use crate::{
     lines::NewlinePositions,
     parse::syntax::{AtomKind, Syntax},
 };
+
+/// A language may contain certain nodes that are in other languages
+/// and should be parsed as such (e.g. HTML <script> nodes containing
+/// JavaScript). This contains how to identify such nodes, and what
+/// languages we should parse them as.
+///
+/// Note that we don't support sub-languages more than one layer deep.
+pub struct TreeSitterSubLanguage {
+    /// How to identify a node. The query must contain exactly one
+    /// capture group (the name is arbitrary).
+    query: ts::Query,
+
+    /// What language parser to use (refers in turn to a TreeSitterConfig).
+    parse_as: guess::Language,
+}
 
 /// Configuration for a tree-sitter parser.
 pub struct TreeSitterConfig {
@@ -37,6 +53,9 @@ pub struct TreeSitterConfig {
     /// Tree-sitter query used for syntax highlighting this
     /// language.
     highlight_query: ts::Query,
+
+    /// Sub-languages in use, if any.
+    sub_languages: Vec<TreeSitterSubLanguage>,
 }
 
 extern "C" {
@@ -114,6 +133,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/bash.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         C => {
@@ -127,6 +147,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/c.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         CPlusPlus => {
@@ -145,6 +166,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     ),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Clojure => {
@@ -160,6 +182,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/clojure.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         CMake => {
@@ -173,6 +196,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/cmake.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         CommonLisp => {
@@ -182,6 +206,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                 atom_nodes: vec!["str_lit", "char_lit"].into_iter().collect(),
                 delimiter_tokens: vec![("(", ")")],
                 highlight_query: ts::Query::new(language, "").unwrap(),
+                sub_languages: vec![],
             }
         }
         CSharp => {
@@ -201,6 +226,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/c-sharp.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Css => {
@@ -214,6 +240,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/css.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Dart => {
@@ -227,6 +254,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/dart.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         EmacsLisp => {
@@ -242,6 +270,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/elisp.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Elixir => {
@@ -257,6 +286,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/elixir.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Elm => {
@@ -270,6 +300,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/elm.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Elvish => {
@@ -283,6 +314,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/elvish.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Gleam => {
@@ -296,6 +328,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/gleam.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Go => {
@@ -313,6 +346,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/go.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Hack => {
@@ -326,6 +360,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/hack.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Hare => {
@@ -341,6 +376,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/hare.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Haskell => {
@@ -354,6 +390,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/haskell.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Hcl => {
@@ -374,6 +411,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/hcl.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Html => {
@@ -397,6 +435,18 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/html.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![
+                    TreeSitterSubLanguage {
+                        query: ts::Query::new(language, "(style_element (raw_text) @contents)")
+                            .unwrap(),
+                        parse_as: Css,
+                    },
+                    TreeSitterSubLanguage {
+                        query: ts::Query::new(language, "(script_element (raw_text) @contents)")
+                            .unwrap(),
+                        parse_as: JavaScript,
+                    },
+                ],
             }
         }
         Janet => {
@@ -419,6 +469,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/janet_simple.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Java => {
@@ -432,6 +483,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/java.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         JavaScript | Jsx => {
@@ -455,6 +507,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/javascript.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Json => {
@@ -468,6 +521,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/json.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Julia => {
@@ -488,6 +542,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/julia.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Kotlin => {
@@ -505,6 +560,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/kotlin.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Lua => {
@@ -520,6 +576,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/lua.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Make => {
@@ -533,6 +590,11 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/make.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![TreeSitterSubLanguage {
+                    query: ts::Query::new(language, "(shell_function (shell_command) @contents)")
+                        .unwrap(),
+                    parse_as: Bash,
+                }],
             }
         }
         Nix => {
@@ -548,6 +610,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/nix.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         OCaml => {
@@ -561,6 +624,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/ocaml.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         OCamlInterface => {
@@ -574,6 +638,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/ocaml.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Pascal => {
@@ -587,6 +652,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/pascal.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Perl => {
@@ -611,6 +677,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/perl.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Php => {
@@ -624,6 +691,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/php.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Python => {
@@ -637,6 +705,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/python.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Qml => {
@@ -656,6 +725,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     ),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Ruby => {
@@ -679,6 +749,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/ruby.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Rust => {
@@ -692,6 +763,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/rust.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Scala => {
@@ -705,6 +777,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/scala.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Sql => {
@@ -718,6 +791,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/sql.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Swift => {
@@ -731,6 +805,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/swift.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Toml => {
@@ -744,6 +819,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/toml.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Tsx => {
@@ -760,6 +836,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     ),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         TypeScript => {
@@ -778,6 +855,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     ),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Yaml => {
@@ -798,6 +876,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/yaml.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
         Zig => {
@@ -815,6 +894,7 @@ pub fn from_language(language: guess::Language) -> TreeSitterConfig {
                     include_str!("../../vendor/highlights/zig.scm"),
                 )
                 .unwrap(),
+                sub_languages: vec![],
             }
         }
     }
@@ -828,6 +908,43 @@ pub fn parse_to_tree(src: &str, config: &TreeSitterConfig) -> tree_sitter::Tree 
         .expect("Incompatible tree-sitter version");
 
     parser.parse(src, None).unwrap()
+}
+
+/// Find any nodes that can be parsed as other languages (e.g. JavaScript embedded in HTML),
+/// and return a map of their node IDs mapped to parsed trees. Every time we see such a node,
+/// we will ignore it and recurse into the root node of the given tree instead.
+pub fn parse_subtrees(
+    src: &str,
+    config: &TreeSitterConfig,
+    tree: &tree_sitter::Tree,
+) -> HashMap<usize, (tree_sitter::Tree, HighlightedNodeIds)> {
+    let mut subtrees = HashMap::new();
+
+    for language in &config.sub_languages {
+        let mut query_cursor = tree_sitter::QueryCursor::new();
+        for m in query_cursor.matches(&language.query, tree.root_node(), src.as_bytes()) {
+            let node = m.nodes_for_capture_index(0).next().unwrap();
+            if node.byte_range().is_empty() {
+                continue;
+            }
+
+            let subconfig = from_language(language.parse_as);
+            let mut parser = ts::Parser::new();
+            parser
+                .set_language(subconfig.language)
+                .expect("Incompatible tree-sitter version");
+            parser
+                .set_included_ranges(&[node.range()])
+                .expect("Incompatible tree-sitter version");
+
+            let tree = parser.parse(src, None).unwrap();
+            let sub_highlights = tree_highlights(&tree, src, &subconfig);
+
+            subtrees.insert(node.id(), (tree, sub_highlights));
+        }
+    }
+
+    subtrees
 }
 
 /// Calculate which tree-sitter node IDs should have which syntax
@@ -970,6 +1087,10 @@ pub fn parse<'a>(
     let tree = parse_to_tree(src, config);
     let highlights = tree_highlights(&tree, src, config);
 
+    // Parse sub-languages, if any, which will be used both for
+    // highlighting and for more precise Syntax nodes where applicable.
+    let subtrees = parse_subtrees(src, config, &tree);
+
     let nl_pos = NewlinePositions::from(src);
     let mut cursor = tree.walk();
 
@@ -977,7 +1098,15 @@ pub fn parse<'a>(
     // each top level syntax item.
     cursor.goto_first_child();
 
-    all_syntaxes_from_cursor(arena, src, &nl_pos, &mut cursor, config, &highlights)
+    all_syntaxes_from_cursor(
+        arena,
+        src,
+        &nl_pos,
+        &mut cursor,
+        config,
+        &highlights,
+        &subtrees,
+    )
 }
 
 fn child_tokens<'a>(src: &'a str, cursor: &mut ts::TreeCursor) -> Vec<Option<&'a str>> {
@@ -1046,12 +1175,13 @@ fn all_syntaxes_from_cursor<'a>(
     cursor: &mut ts::TreeCursor,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
+    subtrees: &HashMap<usize, (tree_sitter::Tree, HighlightedNodeIds)>,
 ) -> Vec<&'a Syntax<'a>> {
     let mut result: Vec<&Syntax> = vec![];
 
     loop {
         result.extend(syntax_from_cursor(
-            arena, src, nl_pos, cursor, config, highlights,
+            arena, src, nl_pos, cursor, config, highlights, subtrees,
         ));
 
         if !cursor.goto_next_sibling() {
@@ -1071,8 +1201,26 @@ fn syntax_from_cursor<'a>(
     cursor: &mut ts::TreeCursor,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
+    subtrees: &HashMap<usize, (tree_sitter::Tree, HighlightedNodeIds)>,
 ) -> Option<&'a Syntax<'a>> {
     let node = cursor.node();
+
+    // See if we should go into a sub-document instead (e.g. embedded JavaScript in HTML).
+    match subtrees.get(&node.id()) {
+        Some((subtree, subhighlights)) => {
+            let mut sub_cursor = subtree.walk();
+            return syntax_from_cursor(
+                arena,
+                src,
+                nl_pos,
+                &mut sub_cursor,
+                config,
+                subhighlights,
+                &HashMap::new(),
+            );
+        }
+        None => {}
+    }
 
     if node.is_error() {
         let position = nl_pos.from_offsets(node.start_byte(), node.end_byte());
@@ -1091,7 +1239,7 @@ fn syntax_from_cursor<'a>(
         atom_from_cursor(arena, src, nl_pos, cursor, highlights)
     } else if node.child_count() > 0 {
         Some(list_from_cursor(
-            arena, src, nl_pos, cursor, config, highlights,
+            arena, src, nl_pos, cursor, config, highlights, subtrees,
         ))
     } else {
         atom_from_cursor(arena, src, nl_pos, cursor, highlights)
@@ -1107,6 +1255,7 @@ fn list_from_cursor<'a>(
     cursor: &mut ts::TreeCursor,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
+    subtrees: &HashMap<usize, (tree_sitter::Tree, HighlightedNodeIds)>,
 ) -> &'a Syntax<'a> {
     let root_node = cursor.node();
 
@@ -1150,21 +1299,21 @@ fn list_from_cursor<'a>(
         let node = cursor.node();
         if node_i < i {
             before_delim.extend(syntax_from_cursor(
-                arena, src, nl_pos, cursor, config, highlights,
+                arena, src, nl_pos, cursor, config, highlights, subtrees,
             ));
         } else if node_i == i {
             inner_open_content = &src[node.start_byte()..node.end_byte()];
             inner_open_position = nl_pos.from_offsets(node.start_byte(), node.end_byte());
         } else if node_i < j {
             between_delim.extend(syntax_from_cursor(
-                arena, src, nl_pos, cursor, config, highlights,
+                arena, src, nl_pos, cursor, config, highlights, subtrees,
             ));
         } else if node_i == j {
             inner_close_content = &src[node.start_byte()..node.end_byte()];
             inner_close_position = nl_pos.from_offsets(node.start_byte(), node.end_byte());
         } else if node_i > j {
             after_delim.extend(syntax_from_cursor(
-                arena, src, nl_pos, cursor, config, highlights,
+                arena, src, nl_pos, cursor, config, highlights, subtrees,
             ));
         }
 
@@ -1284,5 +1433,46 @@ mod tests {
 
         let expected: Vec<&Syntax> = vec![];
         assert_eq!(res, expected);
+    }
+
+    /// Test that HTML with CSS inside it is parsed as such, instead of
+    /// being left as a single atom.
+    #[test]
+    fn test_subtrees() {
+        let arena = Arena::new();
+        let config = from_language(guess::Language::Html);
+        let res = parse(&arena, "<style>.a { color: red; }</style>", &config);
+
+        match res[0] {
+            Syntax::List {
+                info: _,
+                open_position: _,
+                open_content: _,
+                children,
+                close_position: _,
+                close_content: _,
+                num_descendants: _,
+            } => {
+                // <style>, content, </style>.
+                assert_eq!(children.len(), 3);
+                match children[1] {
+                    Syntax::Atom {
+                        info: _,
+                        position: _,
+                        content: _,
+                        kind: _,
+                    } => {
+                        panic!("Style contents is parsed as a single atom");
+                    }
+                    _ => {
+                        // A list is what we want; it shows that the CSS was parsed
+                        // into multiple tokens, so we do not check it further.
+                    }
+                }
+            }
+            _ => {
+                panic!("Top level isn't a list");
+            }
+        };
     }
 }


### PR DESCRIPTION
This allows given nodes (configurable per-language, using tree-sitter's query syntax) to be re-parsed as other languages. The canonical example is CSS or JavaScript inside HTML, which normally would be a single token but now can get the full range of syntax highlighting and tree diffing.

The config sets this up for only two languages: HTML (contains CSS or JavaScript in <script> or <style> tags; we don't support style="" or onclick="" etc. at this point), and Makefiles (contains Bash in $(shell ...) commands). The latter is fairly obscure; the big win is in the former.

It would be nice to also have this support for PHP; however, the HTML parser seems to be a bit confused when asked to parse the partial HTML blocks we get if we just mark the “text” blocks as HTML, so for this to work well, probably the PHP blocks should be parsed as sub-languages of HTML instead of vice versa.

Also, as a minor quibble, there should be support for bash in Perl's backticks (similar to in Makefiles), but the tree-sitter Perl parser does not support backticks at all (it goes into error recovery).

There may have been languages that I've missed, e.g. some languages might have nodes that contain e.g. SQL.

Fixes #382. Potentially relevant to #376.