### PR TITLE
[WIP] Bidirectional Dijkstra

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -337,13 +337,13 @@ fn diff_file_content(
 
             let mut exceeded_graph_limit = false;
 
-            for (lhs_section_nodes, rhs_section_nodes) in possibly_changed {
+            for (lhs_section_nodes, rhs_section_nodes) in possibly_changed.iter() {
                 init_next_prev(&lhs_section_nodes);
                 init_next_prev(&rhs_section_nodes);
 
                 match mark_syntax(
-                    lhs_section_nodes.get(0).copied(),
-                    rhs_section_nodes.get(0).copied(),
+                    &lhs_section_nodes,
+                    &rhs_section_nodes,
                     &mut change_map,
                     graph_limit,
                 ) {

--- a/src/parse/syntax.rs
+++ b/src/parse/syntax.rs
@@ -38,8 +38,6 @@ pub type SyntaxId = NonZeroU32;
 
 /// Fields that are common to both `Syntax::List` and `Syntax::Atom`.
 pub struct SyntaxInfo<'a> {
-    /// The previous node with the same parent as this one.
-    previous_sibling: Cell<Option<&'a Syntax<'a>>>,
     /// The next node with the same parent as this one.
     next_sibling: Cell<Option<&'a Syntax<'a>>>,
     /// The syntax node that occurs before this one, in a depth-first
@@ -69,7 +67,6 @@ pub struct SyntaxInfo<'a> {
 impl<'a> SyntaxInfo<'a> {
     pub fn new() -> Self {
         Self {
-            previous_sibling: Cell::new(None),
             next_sibling: Cell::new(None),
             prev: Cell::new(None),
             parent: Cell::new(None),
@@ -425,7 +422,6 @@ fn set_num_after(nodes: &[&Syntax], parent_num_after: usize) {
     }
 }
 pub fn init_next_prev<'a>(roots: &[&'a Syntax<'a>]) {
-    set_prev_sibling(roots);
     set_next_sibling(roots);
     set_prev(roots, None);
     set_prev_is_contiguous(roots);
@@ -478,21 +474,6 @@ fn set_content_is_unique(nodes: &[&Syntax]) {
     let mut counts = HashMap::new();
     find_nodes_with_unique_content(nodes, &mut counts);
     set_content_is_unique_from_counts(nodes, &counts);
-}
-
-fn set_prev_sibling<'a>(nodes: &[&'a Syntax<'a>]) {
-    for (i, node) in nodes.iter().enumerate() {
-        if i == 0 {
-            continue;
-        }
-
-        let sibling = nodes.get(i - 1).copied();
-        node.info().previous_sibling.set(sibling);
-
-        if let List { children, .. } = node {
-            set_prev_sibling(children);
-        }
-    }
 }
 
 fn set_next_sibling<'a>(nodes: &[&'a Syntax<'a>]) {

--- a/src/parse/syntax.rs
+++ b/src/parse/syntax.rs
@@ -261,10 +261,6 @@ impl<'a> Syntax<'a> {
         }
     }
 
-    pub fn parent(&self) -> Option<&'a Syntax<'a>> {
-        self.info().parent.get()
-    }
-
     pub fn next_sibling(&self) -> Option<&'a Syntax<'a>> {
         self.info().next_sibling.get()
     }


### PR DESCRIPTION
Instead of running the graph search from the start to the end, grow it from both sides at the same time until we meet in the middle. This speeds up the search by ~80% for larger problems; for smaller, it is actually slightly less efficient, but small diffs are already fast, and this does not make them noticeably slower. One would generally expect that the larger the problem, the more gains there are to be had. It also uses significantly less RAM (~30% lower RSS for the slow_{before,after}.rs case), even though the Vertex objects are much larger.

Note that currently, the cost structure in Difftastic makes the search grow really unevenly, since nearly all the cost is borne at the entry of delimiters and nearly none at the exit. This creates a lopsided cost graph, which is great for single searches but makes the backward search look deceptively cheap and causes them to expand a lot of nodes before reaching a middle. (Forcing every other node to be forward and backward does not seem to help significantly.) See e.g. this visualization
of the Dart diff example, where lighter colors are nodes that are settled once, and darker are settled twice (we can see each (lhs,rhs) index pair twice due to differences in the parent stack):

  https://home.samfundet.no/~sesse/bidir-dijkstra-difftastic.html

A larger example (the second hunk of slow_{before,after}.rs), sped up and with a somewhat adjusted cost structure (making the search less lopsided) is also instructive:

  https://home.samfundet.no/~sesse/bidir-dijkstra-difftastic-2.html

The algorithm itself is not particularly difficult, only that the stopping criteria is somewhat subtle (see e.g. https://www.homepages.ucl.ac.uk/~ucahmto/math/2020/05/30/bidirectional-dijkstra.html, although we use one priority queue and not two). What is really, _really_ tricky is actually creating the backward edges on-the-fly, so that we construct the exact same set of edges forwards and backwards. (If we do not do this, and miss some backward edges, the algorithm will assume it's seen the best possible meeting point too early, and we can end up with a suboptimal path.)

Actually, it's impossible in the general case, as the set of vertices and thus edges constructed in Difftastic is path-dependent;
Vertex objects with different parent stacks can be considered equal. This creates some complications for reconstruction of the path, and even more so for verification, as one cannot simply assert that the forward and backward edge sets are identical in debug mode. Thus, results may be slightly different between unidirectional and bidirectional searches, even though they conceptually search the same graph.

WIP: End-to-end tests need to be manually verified and updated; there are some diffs, and they may be bugs or equal-cost paths or just an artifact of first-seen-wins as mentioned above.