### PR TITLE
Add `cargo binstall` metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ include = [
         "/README.md",
 ]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/difft-{ target }.{ archive-format }"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [dependencies]
 regex = "1.5.4"
 clap = { version = "3.1.8", features = ["cargo", "env", "wrap_help"] }


### PR DESCRIPTION
Right now `cargo binstall` cannot find the pre-compiled `difftastic` assets:

```
~
❯ cargo binstall difftastic
 INFO resolve: Resolving package: 'difftastic'
 WARN resolve: The package will be installed from source (with cargo)
Do you wish to continue? yes/[no]
? no
 WARN Installation cancelled

~ took 18s
❯ cargo binstall difftastic --pkg-url="{ repo }/releases/download/{ version }/difft-{ target }.{ archive-format }"
 INFO resolve: Resolving package: 'difftastic'
 WARN resolve: The package will be downloaded from github.com
 INFO resolve: This will install the following binaries:
 INFO resolve:   - difft (difft -> /home/michel/.cargo/bin/difft-v0.38.0)
 INFO resolve: And create (or update) the following symlinks:
 INFO resolve:   - difft (/home/michel/.cargo/bin/difft -> difft-v0.38.0)
Do you wish to continue? yes/[no]
? yes
 INFO install: Installing binaries...
 INFO Done in 9.277840305s
```

Adding this `pkg-url` override to `Cargo.toml` allows `binstall` to find the pre-compiled archives:

```
~
❯ cargo binstall --manifest-path ~/src/github/Wilfred/difftastic/Cargo.toml difftastic
 INFO resolve: Resolving package: 'difftastic'
 INFO resolve: difftastic v0.38.0 is already installed, use --force to override
 INFO Done in 5.327886ms

~
❯ cargo binstall --manifest-path ~/src/github/Wilfred/difftastic/Cargo.toml difftastic --force
 INFO resolve: Resolving package: 'difftastic'
 WARN resolve: The package will be downloaded from github.com
 INFO resolve: This will install the following binaries:
 INFO resolve:   - difft (difft -> /home/michel/.cargo/bin/difft-v0.38.0)
 INFO resolve: And create (or update) the following symlinks:
 INFO resolve:   - difft (/home/michel/.cargo/bin/difft -> difft-v0.38.0)
Do you wish to continue? yes/[no]
? yes
 INFO install: Installing binaries...
 INFO Done in 5.484314255s
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>