### PR TITLE
Modify. For the second and subsequent hunks, difft outputs file name in the default color.

### DIFF
--- a/sample_files/dir_after/has_many_hunk.py
+++ b/sample_files/dir_after/has_many_hunk.py
@@ -1,0 +1,404 @@
+def function001():
+    print("function001 start")
+
+def function002():
+    pass
+
+def function003():
+    pass
+
+def function004():
+    pass
+
+def function005():
+    pass
+
+def function006():
+    pass
+
+def function007():
+    pass
+
+def function008():
+    pass
+
+def function009():
+    pass
+
+def function010():
+    pass
+
+def function011():
+    print("function011 start")
+
+def function012():
+    pass
+
+def function013():
+    pass
+
+def function014():
+    pass
+
+def function015():
+    pass
+
+def function016():
+    pass
+
+def function017():
+    pass
+
+def function018():
+    pass
+
+def function019():
+    pass
+
+def function020():
+    pass
+
+def function021():
+    print("function021 start")
+    pass
+
+def function022():
+    pass
+
+def function023():
+    pass
+
+def function024():
+    pass
+
+def function025():
+    pass
+
+def function026():
+    pass
+
+def function027():
+    pass
+
+def function028():
+    pass
+
+def function029():
+    pass
+
+def function030():
+    pass
+
+def function031():
+    print("function031 start")
+    pass
+
+def function032():
+    pass
+
+def function033():
+    pass
+
+def function034():
+    pass
+
+def function035():
+    pass
+
+def function036():
+    pass
+
+def function037():
+    pass
+
+def function038():
+    pass
+
+def function039():
+    pass
+
+def function040():
+    pass
+
+def function041(**args):
+    pass
+
+def function042():
+    pass
+
+def function043():
+    pass
+
+def function044():
+    pass
+
+def function045():
+    pass
+
+def function046():
+    pass
+
+def function047():
+    pass
+
+def function048():
+    pass
+
+def function049():
+    pass
+
+def function050():
+    pass
+
+# def function051():
+#     pass
+
+def function052():
+    pass
+
+def function053():
+    pass
+
+def function054():
+    pass
+
+def function055():
+    pass
+
+def function056():
+    pass
+
+def function057():
+    pass
+
+def function058():
+    pass
+
+def function059():
+    pass
+
+def function060():
+    pass
+
+
+def function062():
+    pass
+
+def function063():
+    pass
+
+def function064():
+    pass
+
+def function065():
+    pass
+
+def function066():
+    pass
+
+def function067():
+    pass
+
+def function068():
+    pass
+
+def function069():
+    pass
+
+def function070():
+    pass
+
+def function071():
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+    function001()
+
+def function072():
+    pass
+
+def function073():
+    pass
+
+def function074():
+    pass
+
+def function075():
+    pass
+
+def function076():
+    pass
+
+def function077():
+    pass
+
+def function078():
+    pass
+
+def function079():
+    pass
+
+def function080():
+    pass
+
+def function081():
+    if True:
+        pass
+    pass
+
+def function082():
+    pass
+
+def function083():
+    pass
+
+def function084():
+    pass
+
+def function085():
+    pass
+
+def function086():
+    pass
+
+def function087():
+    pass
+
+def function088():
+    pass
+
+def function089():
+    pass
+
+def function090():
+    pass
+
+def function091():
+    function001()
+
+def function092():
+    pass
+
+def function093():
+    pass
+
+def function094():
+    pass
+
+def function095():
+    pass
+
+def function096():
+    pass
+
+def function097():
+    pass
+
+def function098():
+    pass
+
+def function099():
+    pass
+
+def function100():
+    pass
+

--- a/sample_files/dir_before/has_many_hunk.py
+++ b/sample_files/dir_before/has_many_hunk.py
@@ -1,0 +1,300 @@
+def function001():
+    pass
+
+def function002():
+    pass
+
+def function003():
+    pass
+
+def function004():
+    pass
+
+def function005():
+    pass
+
+def function006():
+    pass
+
+def function007():
+    pass
+
+def function008():
+    pass
+
+def function009():
+    pass
+
+def function010():
+    pass
+
+def function011():
+    pass
+
+def function012():
+    pass
+
+def function013():
+    pass
+
+def function014():
+    pass
+
+def function015():
+    pass
+
+def function016():
+    pass
+
+def function017():
+    pass
+
+def function018():
+    pass
+
+def function019():
+    pass
+
+def function020():
+    pass
+
+def function021():
+    pass
+
+def function022():
+    pass
+
+def function023():
+    pass
+
+def function024():
+    pass
+
+def function025():
+    pass
+
+def function026():
+    pass
+
+def function027():
+    pass
+
+def function028():
+    pass
+
+def function029():
+    pass
+
+def function030():
+    pass
+
+def function031():
+    pass
+
+def function032():
+    pass
+
+def function033():
+    pass
+
+def function034():
+    pass
+
+def function035():
+    pass
+
+def function036():
+    pass
+
+def function037():
+    pass
+
+def function038():
+    pass
+
+def function039():
+    pass
+
+def function040():
+    pass
+
+def function041():
+    pass
+
+def function042():
+    pass
+
+def function043():
+    pass
+
+def function044():
+    pass
+
+def function045():
+    pass
+
+def function046():
+    pass
+
+def function047():
+    pass
+
+def function048():
+    pass
+
+def function049():
+    pass
+
+def function050():
+    pass
+
+def function051():
+    pass
+
+def function052():
+    pass
+
+def function053():
+    pass
+
+def function054():
+    pass
+
+def function055():
+    pass
+
+def function056():
+    pass
+
+def function057():
+    pass
+
+def function058():
+    pass
+
+def function059():
+    pass
+
+def function060():
+    pass
+
+def function061():
+    pass
+
+def function062():
+    pass
+
+def function063():
+    pass
+
+def function064():
+    pass
+
+def function065():
+    pass
+
+def function066():
+    pass
+
+def function067():
+    pass
+
+def function068():
+    pass
+
+def function069():
+    pass
+
+def function070():
+    pass
+
+def function071():
+    pass
+
+def function072():
+    pass
+
+def function073():
+    pass
+
+def function074():
+    pass
+
+def function075():
+    pass
+
+def function076():
+    pass
+
+def function077():
+    pass
+
+def function078():
+    pass
+
+def function079():
+    pass
+
+def function080():
+    pass
+
+def function081():
+    pass
+
+def function082():
+    pass
+
+def function083():
+    pass
+
+def function084():
+    pass
+
+def function085():
+    pass
+
+def function086():
+    pass
+
+def function087():
+    pass
+
+def function088():
+    pass
+
+def function089():
+    pass
+
+def function090():
+    pass
+
+def function091():
+    pass
+
+def function092():
+    pass
+
+def function093():
+    pass
+
+def function094():
+    pass
+
+def function095():
+    pass
+
+def function096():
+    pass
+
+def function097():
+    pass
+
+def function098():
+    pass
+
+def function099():
+    pass
+
+def function100():
+    pass
+

--- a/src/display/style.rs
+++ b/src/display/style.rs
@@ -364,9 +364,11 @@ pub fn apply_colors(
     style_lines(&lines, &styles)
 }
 
-fn apply_header_color(s: &str, use_color: bool, background: BackgroundColor) -> String {
+fn apply_header_color(s: &str, use_color: bool, background: BackgroundColor, hunk_num: usize) -> String {
     if use_color {
-        if background.is_dark() {
+        if hunk_num != 1 {
+            s.to_string()
+        } else if background.is_dark() {
             s.bright_yellow().to_string()
         } else {
             s.yellow().to_string()
@@ -424,11 +426,13 @@ pub fn header(
         rhs_display_path,
         display_options.use_color,
         display_options.background_color,
+        hunk_num
     );
     let lhs_path_pretty = apply_header_color(
         lhs_display_path,
         display_options.use_color,
         display_options.background_color,
+        hunk_num
     );
     if hunk_num == 1 && lhs_display_path != rhs_display_path && display_options.in_vcs {
         let renamed = format!("Renamed {} to {}", lhs_path_pretty, rhs_path_pretty);


### PR DESCRIPTION
Resolves #400

For the second and subsequent hanks, difft outputs file name in the default color.
I thought it would be inconvenient to hide file names when there are many hunks, so I changed the output to use the default color.

Output Example:

![OutputExample](https://user-images.githubusercontent.com/104247605/204161631-13abbc41-52d1-4cd4-a126-a5a35dd6a8ad.png)
