### PR TITLE
add option and help text for --strip-trailing-cr feature

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -249,6 +249,10 @@ fn app() -> clap::Command<'static> {
                 .hide(true)
                 .allow_invalid_utf8(true),
         )
+        .arg(
+            Arg::new("strip-trailing-cr").long("strip-trailing-cr")
+                .help("Strip carriage return on input (CRLF -> LF).")
+        )
         .arg_required_else_help(true)
 }
 


### PR DESCRIPTION
This is a work in progress, no functionality present at the moment.
What are the thoughts please, is it worth developing ?

![image](https://user-images.githubusercontent.com/11034264/219421269-ba030f5f-8a50-4bc6-8646-3a0285d35da7.png)
