### PR TITLE
Relax version dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,10 @@ crossterm = { version = "0.25.0", features = [] }
 
 [dev-dependencies]
 # This is the last version of assert_cmd that supports rustc 1.57.
-assert_cmd = "=2.0.5"
+assert_cmd = ">= 2, <= 2.0.5"
 # Predicates is a dependency of assert_cmd, but needs pinning to the
 # last version that supports rustc 1.57.
-predicates = "=2.1.1"
+predicates = ">= 2, <= 2.1.1"
 
 pretty_assertions = "1.2.1"
 


### PR DESCRIPTION
For dependencies we're pinning for Rust 1.57 compatibility, specify the range of versions allowed rather than just pinning to the maximum version allowed.

This makes it easier for Linux distribution packaging, where a different version might already be packaged.