### PR TITLE
Add instructions for one-off wrapper

### DIFF
--- a/manual/src/git.md
+++ b/manual/src/git.md
@@ -10,6 +10,21 @@ $ GIT_EXTERNAL_DIFF=difft git log -p --ext-diff
 $ GIT_EXTERNAL_DIFF=difft git show e96a7241760319 --ext-diff
 ```
 
+A wrapper function makes these one-off commands more convenient:
+```sh
+# add to ~/.bashrc
+gitt() {
+    GIT_EXTERNAL_DIFF=difft git $1 --ext-diff $@[2,-1]
+}
+```
+
+Then use `gitt` instead of `git`:
+```
+$ gitt diff
+$ gitt log -p
+$ gitt show e96a7241760319
+```
+
 If you want to use difftastic by default, use `git config`.
 
 ```


### PR DESCRIPTION
I find a convenience wrapper to opt-in to `difft` behavior works best for me, so sharing instructions.

The reason for not wanting to fully replace default `git` behavior is that I sometimes use my `.gitconfig` on machines without `difftastic` installed. I also sometimes want to opt-out of `difft` behavior in order to see whitespace changes, but I couldn't find an easy way to do that once overriding default diff.

I use difft behavior more often than not, so actually use a shorter `gt` alias instead of `gitt`, but figured the instructions would be clearer with the longer version.