### PR TITLE
doc: update mercurial configuration example

### DIFF
--- a/manual/src/mercurial.md
+++ b/manual/src/mercurial.md
@@ -19,7 +19,6 @@ following to your `.hgrc` to run difftastic with `hg dft`.
 ```
 [extdiff]
 cmd.dft = difft
-opts.dft = --missing-as-empty
 ```
 
 ## hg log -p


### PR DESCRIPTION
The `--missing-as-empty` option has been removed in version 0.46.