### PR TITLE
doc: extend description of mercurial configuration

### DIFF
--- a/manual/src/mercurial.md
+++ b/manual/src/mercurial.md
@@ -10,8 +10,8 @@ your `.hgrc`.
 extdiff =
 ```
 
-You can then run `hg extdiff -p difft` (assumes the `difft` binary is
-on your `$PATH`).
+You can then run `hg extdiff -p difft` instead of `hg diff`
+(assumes the `difft` binary is on your `$PATH`).
 
 You can also define an alias to run difftastic with hg. Add the
 following to your `.hgrc` to run difftastic with `hg dft`.
@@ -19,8 +19,13 @@ following to your `.hgrc` to run difftastic with `hg dft`.
 ```
 [extdiff]
 cmd.dft = difft
-opts.dft = --missing-as-empty
+# You can add further options which will be passed to the command line, e.g.
+# opts.dft = --background light
 ```
+
+All options of `hg diff` are also supported by `hg dft`; for example,
+`hg dft --stat` will show statistics of changed lines and `hg dft -r 42 -r 45`
+will show the diff between two revisions.
 
 ## hg log -p
 


### PR DESCRIPTION
Mention that command-line arguments can be added, and that `hg dft` supports all arguments `hg diff` does.
Seeing the `hg dft` incantation below, it took me a moment to realise that `hg dft` will then support comparing revisions.

Perhaps a better change would be to tweak the description of the `hg log -p` section: any two revisions can be compared like this, not just the working directory to the latest revision checked out.