### PR TITLE
Create draft release in pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         env:
           # (required)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Create a draft release so we can add the changelog before publishing it
+          # so the changelog is included in the release email
+          draft: true
 
   upload-assets:
     strategy:


### PR DESCRIPTION
Github sends out an email on creating/publishing a release (Watch -> Custom -> releases) and that email contains whatever is at that point in the release description. As the pipeline currently creates a release without a description the email is mostly empty. As the changelog is added manually later, lets only create a draft release which can be "published" after adding the changelog. The release email then contains a proper changelog entry.