### PR TITLE
Add --hidden and --no-ignore options to walk all files in directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Fixed an issue with line-based diffing where only the first line in a
 large changed region was highlighted. This was particularly noticeable
 when diffing brand new files.
 
+Added `--hidden` and `--no-ignore` options to not exclude ignored files from
+directory diffing.
+
 ### Display
 
 Fixed an issue when reporting changes in binary files, where trailing

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,9 @@ use strum::IntoEnumIterator;
 use typed_arena::Arena;
 
 use crate::diff::sliders::fix_all_sliders;
-use crate::options::{DiffOptions, DisplayMode, DisplayOptions, FileArgument, Mode};
+use crate::options::{
+    DiffOptions, DirectoryOptions, DisplayMode, DisplayOptions, FileArgument, Mode,
+};
 use crate::summary::{DiffResult, FileContent, FileFormat};
 use crate::syntax::init_next_prev;
 use crate::{
@@ -252,6 +254,7 @@ fn main() {
                         rhs_path,
                         &display_options,
                         &diff_options,
+                        &directory_options,
                         &language_overrides,
                     );
 
@@ -724,6 +727,7 @@ fn diff_directories<'a>(
     rhs_dir: &'a Path,
     display_options: &DisplayOptions,
     diff_options: &DiffOptions,
+    directory_options: &DirectoryOptions,
     overrides: &[(LanguageOverride, Vec<glob::Pattern>)],
 ) -> impl ParallelIterator<Item = DiffResult> + 'a {
     let diff_options = diff_options.clone();
@@ -733,7 +737,7 @@ fn diff_directories<'a>(
     // We greedily list all files in the directory, and then diff them
     // in parallel. This is assuming that diffing is slower than
     // enumerating files, so it benefits more from parallelism.
-    let paths = relative_paths_in_either(lhs_dir, rhs_dir);
+    let paths = relative_paths_in_either(lhs_dir, rhs_dir, directory_options);
 
     paths.into_par_iter().map(move |rel_path| {
         info!("Relative path is {:?} inside {:?}", rel_path, lhs_dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,7 @@ fn main() {
         Mode::Diff {
             diff_options,
             display_options,
+            directory_options,
             set_exit_code,
             language_overrides,
             lhs_path,
@@ -260,7 +261,7 @@ fn main() {
                             .iter()
                             .any(|diff_result| diff_result.has_reportable_change());
                         display::json::print_directory(results, display_options.print_unchanged);
-                    } else if display_options.sort_paths {
+                    } else if directory_options.sort_paths {
                         let mut result: Vec<DiffResult> = diff_iter.collect();
                         result.sort_unstable_by(|a, b| a.display_path.cmp(&b.display_path));
                         for diff_result in result {

--- a/src/options.rs
+++ b/src/options.rs
@@ -47,7 +47,6 @@ pub(crate) struct DisplayOptions {
     pub(crate) display_width: usize,
     pub(crate) num_context_lines: u32,
     pub(crate) syntax_highlight: bool,
-    pub(crate) sort_paths: bool,
 }
 
 impl Default for DisplayOptions {
@@ -61,7 +60,6 @@ impl Default for DisplayOptions {
             display_width: 80,
             num_context_lines: 3,
             syntax_highlight: true,
-            sort_paths: false,
         }
     }
 }
@@ -87,6 +85,11 @@ impl Default for DiffOptions {
             strip_cr: false,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DirectoryOptions {
+    pub(crate) sort_paths: bool,
 }
 
 fn app() -> clap::Command<'static> {
@@ -442,6 +445,7 @@ pub(crate) enum Mode {
     Diff {
         diff_options: DiffOptions,
         display_options: DisplayOptions,
+        directory_options: DirectoryOptions,
         set_exit_code: bool,
         language_overrides: Vec<(LanguageOverride, Vec<glob::Pattern>)>,
         /// The path where we can read the LHS file. This is often a
@@ -801,7 +805,6 @@ pub(crate) fn parse_args() -> Mode {
                 display_width,
                 num_context_lines,
                 syntax_highlight,
-                sort_paths,
             };
 
             let display_path = path.to_string_lossy().to_string();
@@ -838,12 +841,13 @@ pub(crate) fn parse_args() -> Mode {
         display_width,
         num_context_lines,
         syntax_highlight,
-        sort_paths,
     };
+    let directory_options = DirectoryOptions { sort_paths };
 
     Mode::Diff {
         diff_options,
         display_options,
+        directory_options,
         set_exit_code,
         language_overrides,
         lhs_path,

--- a/src/options.rs
+++ b/src/options.rs
@@ -89,6 +89,10 @@ impl Default for DiffOptions {
 
 #[derive(Debug, Clone)]
 pub(crate) struct DirectoryOptions {
+    /// Whether to search hidden files and directories.
+    pub(crate) include_hidden: bool,
+    /// Whether to not respect ignore file rules.
+    pub(crate) no_ignore: bool,
     pub(crate) sort_paths: bool,
 }
 
@@ -296,6 +300,14 @@ When multiple overrides are specified, the first matching override wins."))
                 .multiple_values(true)
                 .hide(true)
                 .allow_invalid_utf8(true),
+        )
+        .arg(
+            Arg::new("hidden").long("hidden")
+                .help("When diffing a directory, search hidden files and directories.")
+        )
+        .arg(
+            Arg::new("no-ignore").long("no-ignore")
+                .help("When diffing a directory, don't respect ignore files such as .gitignore.")
         )
         .arg(
             Arg::new("sort-paths").long("sort-paths")
@@ -685,6 +697,8 @@ pub(crate) fn parse_args() -> Mode {
 
     let syntax_highlight = matches.value_of("syntax-highlight") == Some("on");
 
+    let include_hidden = matches.is_present("hidden");
+    let no_ignore = matches.is_present("no-ignore");
     let sort_paths = matches.is_present("sort-paths");
 
     let graph_limit = matches
@@ -842,7 +856,11 @@ pub(crate) fn parse_args() -> Mode {
         num_context_lines,
         syntax_highlight,
     };
-    let directory_options = DirectoryOptions { sort_paths };
+    let directory_options = DirectoryOptions {
+        include_hidden,
+        no_ignore,
+        sort_paths,
+    };
 
     Mode::Diff {
         diff_options,


### PR DESCRIPTION
The `ignore::Walk` excludes various files by default. It might makes sense if
user runs difft command manually, but difft can also be used as a directory
diff backend of version control tools. In that case, extra filtering is rather
problematic than useful.

The `--hidden` and `--no-ignore` flags are copied from ripgrep. We can add more
`--no-ignore-<kind>` as needed. For my use case, these two flags are good enough.
Alternatively, we can change the default to not exclude hidden (or dot) files.
That's sufficient for my needs, but I'm not sure if that's desired. The major
problem I have right now is that .gitignore changes are excluded (because it's
a "hidden" file.)

https://github.com/BurntSushi/ripgrep/blob/14.0.3/crates/core/flags/hiargs.rs#L889
https://github.com/BurntSushi/ripgrep/blob/14.0.3/crates/ignore/src/dir.rs#L586
