### PR TITLE
Fix dir-diff paths merging to not add duplicated entries from remainder

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -291,8 +291,18 @@ pub(crate) fn relative_paths_in_either(lhs_dir: &Path, rhs_dir: &Path) -> Vec<Pa
         }
     }
 
-    paths.extend(lhs_paths.into_iter().skip(i));
-    paths.extend(rhs_paths.into_iter().skip(j));
+    paths.extend(
+        lhs_paths[i..]
+            .iter()
+            .filter(|&path| !seen.contains(path))
+            .cloned(),
+    );
+    paths.extend(
+        rhs_paths[j..]
+            .iter()
+            .filter(|&path| !seen.contains(path))
+            .cloned(),
+    );
 
     paths
 }


### PR DESCRIPTION
If `lhs_paths` and `rhs_paths` are `["a", "c"]` and `["a", "b", "c"]` respectively, the loop ends with `paths = ["a", "c", "b"], i = j = 2`. We still need to deduplicate "c" from the `rhs_paths`.

.into_iter() can't be used anymore since the seen set still borrows the paths.