### PR TITLE
manual: fix instructions for adding new parser

### DIFF
--- a/manual/src/adding_a_parser.md
+++ b/manual/src/adding_a_parser.md
@@ -97,8 +97,8 @@ Json => "json",
 ```
 
 There may also file names or shebangs associated with your language; configure those
-by adapting the `LANG_FILE_NAMES` constant and the `from_shebang` method in that file, respectively.
-Add any file extensions associated to your language to the `LANG_EXTENSIONS` constant.
+by adapting the `language_globs`, `from_emacs_mode_header` and `from_shebang` functions
+in that file.
 [GitHub's linguist definitions](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
 are a useful source of common file extensions.
 


### PR DESCRIPTION
The `LANG_*` lists were removed and replaced with functions in 4d85b5c15e60e5cfc396a35b3686df4d7210a925.