### PR TITLE
ZCML is XML

### DIFF
--- a/src/parse/guess_language.rs
+++ b/src/parse/guess_language.rs
@@ -368,6 +368,7 @@ pub(crate) fn language_globs(language: Language) -> Vec<glob::Pattern> {
             "*.xsd",
             "*.xsl",
             "*.xslt",
+            "*.zcml",
             "App.config",
             "nuget.config",
             "packages.config",


### PR DESCRIPTION
Zope and Plone ZCML (Zope Configuration Markup Language) is XML.