### PR TITLE
Allow JSON output to respect skip-unchanged

### DIFF
--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -14,7 +14,7 @@ use crate::{
     summary::{DiffResult, FileContent, FileFormat},
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 enum Status {
     Unchanged,

--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -273,8 +273,12 @@ impl Highlight {
     }
 }
 
-pub(crate) fn print_directory(diffs: Vec<DiffResult>) {
-    let files = diffs.iter().map(File::from).collect::<Vec<File>>();
+pub(crate) fn print_directory(diffs: Vec<DiffResult>, print_unchanged: bool) {
+    let files = diffs
+        .iter()
+        .map(File::from)
+        .filter(|f| print_unchanged || f.status != Status::Unchanged)
+        .collect::<Vec<File>>();
     println!(
         "{}",
         serde_json::to_string(&files).expect("failed to serialize files")

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ fn main() {
                         encountered_changes = results
                             .iter()
                             .any(|diff_result| diff_result.has_reportable_change());
-                        display::json::print_directory(results);
+                        display::json::print_directory(results, display_options.print_unchanged);
                     } else if display_options.sort_paths {
                         let mut result: Vec<DiffResult> = diff_iter.collect();
                         result.sort_unstable_by(|a, b| a.display_path.cmp(&b.display_path));


### PR DESCRIPTION
Today, JSON output doesn't respect the `skip-unchanged` param, and outputs all files regardless. This can result in unnecessarily big outputs. 

This fixes it