### PR TITLE
Add linked from_source.md

### DIFF
--- a/manual/src/from_source.md
+++ b/manual/src/from_source.md
@@ -1,0 +1,31 @@
+# Installation from Source
+
+You will need the rust toolchain. You can get it using [rustup](https://rustup.rs/).
+
+## Cargo Installation
+
+You can install the binary directly from cargo:
+
+```
+$ cargo install difftastic
+```
+
+## Compilation
+
+To compile from source, clone the repo and then run:
+
+```
+$ cargo build
+```
+
+Then to install (by default to `$HOME/.cargo/bin`):
+
+```
+$ cargo install
+```
+
+Or simply use with:
+
+```
+$ cargo run
+```


### PR DESCRIPTION
The manual page links to a "From Source" page but it is missing. I did my best to document the process.