### PR TITLE
Add tab completion for documented `dlog` alias

### DIFF
--- a/manual/src/git.md
+++ b/manual/src/git.md
@@ -71,7 +71,7 @@ equivalent to the one-off commands shown above.
 ```ini
 # `git dlog` to show `git log -p` with difftastic.
 [alias]
-        dlog = "!f() { GIT_EXTERNAL_DIFF=difft git log -p --ext-diff $@; }; f"
+        dlog = "!f() { : git log ; GIT_EXTERNAL_DIFF=difft git log -p --ext-diff $@; }; f"
 ```
 
 ## Difftastic By Default


### PR DESCRIPTION
There's a feature of Git's completion scripts that allows completing function aliases[1]:

> If you use complex aliases of form '!f() { ... }; f', you can use the null
> command ':' as the first command in the function body to declare the desired
> completion style

This allows completion:

    $ git dlog --pat<tab>
    --patch             --patch-with-raw    --patch-with-stat   --patience

Tested on `bash`, though I believe this should also work with `zsh` and `tsch` since their respective completion scripts also make use of the `bash` one

[1] https://git.kernel.org/pub/scm/git/git.git/tree/contrib/completion/git-completion.bash?id=11c821f2f2a31e70fb5cc449f9a29401c333aad2#n26