### PR TITLE
Much shorter version of dlog alias in git documentation

### DIFF
--- a/manual/src/git.md
+++ b/manual/src/git.md
@@ -71,7 +71,7 @@ equivalent to the one-off commands shown above.
 ```ini
 # `git dlog` to show `git log -p` with difftastic.
 [alias]
-        dlog = "!f() { : git log ; GIT_EXTERNAL_DIFF=difft git log -p --ext-diff $@; }; f"
+        dlog = "-c diff.external=difft log -p --ext-diff"
 ```
 
 ## Difftastic By Default


### PR DESCRIPTION
Use `-c` to set config instead of environment variable, so no need for building shell command