### PR TITLE
fix: out of bounds panic when diffing large number of words

### DIFF
--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -515,14 +515,16 @@ pub(crate) fn print(
                     None => vec![" ".repeat(source_dims.content_width)],
                 };
                 let rhs_line = match rhs_line_num {
-                    Some(rhs_line_num) => split_and_apply(
-                        rhs_lines[rhs_line_num.as_usize()],
-                        source_dims.content_width,
-                        display_options.tab_width,
-                        rhs_highlights.get(rhs_line_num).unwrap_or(&vec![]),
-                        Side::Right,
-                    ),
-                    None => vec!["".into()],
+                    Some(rhs_line_num) if rhs_line_num.as_usize() < rhs_lines.len() => {
+                        split_and_apply(
+                            rhs_lines[rhs_line_num.as_usize()],
+                            source_dims.content_width,
+                            display_options.tab_width,
+                            rhs_highlights.get(rhs_line_num).unwrap_or(&vec![]),
+                            Side::Right,
+                        )
+                    }
+                    _ => vec!["".into()],
                 };
 
                 for (i, (lhs_line, rhs_line)) in zip_pad_shorter(&lhs_line, &rhs_line)


### PR DESCRIPTION
*I dropped all the old text because it does not make sense anymore.*

The problem is basically that Rust's [`str::lines()`](https://doc.rust-lang.org/std/primitive.str.html#method.lines) will return the same number of lines regardless of the last character being a new line or not, and the assumptions made on *inline* and *side-by-side* display implementations depends on having a clear distinction of those cases.

~Those changes introduces a function that will chain an additional element when the string ends with a newline. I'm not aware of any function from stdlib that does what we need (and I couldn't find one by looking at the documentation), the closest one was `split`, but it has obvious implications (`\r\n`, for example).~

This does solves #688, #694, #682 and #681, I tested all the provided files and they're all working without any panics.

Update 2024-07-08:

I reworked on this patch and now it does not add a new line to the end of the string, therefore, all tests are passing, including the regression ones (which was failing before). In this new revision it fixes #682 again, which involves `--display=inline` and was not working anymore when I initially merged the changes from master into my branch.

I also tested another case that I found out and it fixes #656.

The new approach is more hacky: in one case it just removes the additional line range when the line is empty, and in another case it just checks if the index is within range before trying to access the index. However, unlike the previous solution, this one does not fail the regression tests.