### PR TITLE
Fix memory leak in neighbours array.

### DIFF
--- a/src/diff/dijkstra.rs
+++ b/src/diff/dijkstra.rs
@@ -42,7 +42,7 @@ fn shortest_vertex_path<'s, 'b>(
                 }
 
                 set_neighbours(current, vertex_arena, &mut seen);
-                for neighbour in current.neighbours.borrow().as_ref().unwrap() {
+                for neighbour in *current.neighbours.borrow().as_ref().unwrap() {
                     let (edge, next) = neighbour;
                     let distance_to_next = distance + edge.cost();
 
@@ -128,7 +128,7 @@ fn edge_between<'s, 'b>(before: &Vertex<'s, 'b>, after: &Vertex<'s, 'b>) -> Edge
 
     let mut shortest_edge: Option<Edge> = None;
     if let Some(neighbours) = &*before.neighbours.borrow() {
-        for neighbour in neighbours {
+        for neighbour in *neighbours {
             let (edge, next) = *neighbour;
             // If there are multiple edges that can take us to `next`,
             // prefer the shortest.

--- a/src/diff/graph.rs
+++ b/src/diff/graph.rs
@@ -51,7 +51,7 @@ use crate::{
 /// ```
 #[derive(Debug, Clone)]
 pub(crate) struct Vertex<'s, 'b> {
-    pub(crate) neighbours: RefCell<Option<Vec<(Edge, &'b Vertex<'s, 'b>)>>>,
+    pub(crate) neighbours: RefCell<Option<&'b [(Edge, &'b Vertex<'s, 'b>)]>>,
     pub(crate) predecessor: Cell<Option<(u32, &'b Vertex<'s, 'b>)>>,
     // TODO: experiment with storing SyntaxId only, and have a HashMap
     // from SyntaxId to &Syntax.
@@ -773,7 +773,8 @@ pub(crate) fn set_neighbours<'s, 'b>(
         "Must always find some next steps if node is not the end"
     );
 
-    v.neighbours.replace(Some(neighbours));
+    v.neighbours
+        .replace(Some(alloc.alloc_slice_copy(neighbours.as_slice())));
 }
 
 pub(crate) fn populate_change_map<'s, 'b>(

--- a/src/diff/stack.rs
+++ b/src/diff/stack.rs
@@ -1,9 +1,9 @@
-use std::rc::Rc;
+use bumpalo::Bump;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct Node<T> {
+struct Node<'b, T> {
     val: T,
-    next: Option<Rc<Node<T>>>,
+    next: Option<&'b Node<'b, T>>,
 }
 
 /// A persistent stack.
@@ -11,11 +11,11 @@ struct Node<T> {
 /// This is similar to `Stack` from the rpds crate, but it's faster
 /// and uses less memory.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct Stack<T> {
-    head: Option<Rc<Node<T>>>,
+pub(crate) struct Stack<'b, T> {
+    head: Option<&'b Node<'b, T>>,
 }
 
-impl<T> Stack<T> {
+impl<'b, T> Stack<'b, T> {
     pub(crate) fn new() -> Self {
         Self { head: None }
     }
@@ -24,15 +24,15 @@ impl<T> Stack<T> {
         self.head.as_deref().map(|n| &n.val)
     }
 
-    pub(crate) fn pop(&self) -> Option<Stack<T>> {
+    pub(crate) fn pop(&self) -> Option<Stack<'b, T>> {
         self.head.as_deref().map(|n| Self {
             head: n.next.clone(),
         })
     }
 
-    pub(crate) fn push(&self, v: T) -> Stack<T> {
+    pub(crate) fn push(&self, v: T, alloc: &'b Bump) -> Stack<'b, T> {
         Self {
-            head: Some(Rc::new(Node {
+            head: Some(alloc.alloc(Node {
                 val: v,
                 next: self.head.clone(),
             })),


### PR DESCRIPTION
Vertex is allocated on the arena, so it is never dropped; then it cannot contain a Vec allocated on the regular heap without leaking memory. Replace the Vec with a slice allocated on the arena, which seems to fix most of the leaks. (Some may remain; I haven't checked fully.) It should also be slightly more memory-efficient.

It's not clear that we actually need the RefCell instead of just putting Option directly into the structure, but I've let it stay.

This issue was probably introduced in a71d6118cf52.