### PR TITLE
Fix small typo in cluster.c

### DIFF
--- a/vendored_parsers/tree-sitter-c/examples/cluster.c
+++ b/vendored_parsers/tree-sitter-c/examples/cluster.c
@@ -2289,7 +2289,7 @@ void clusterSetGossipEntry(clusterMsg *hdr, int i, clusterNode *n) {
 }
 
 /* Send a PING or PONG packet to the specified node, making sure to add enough
- * gossip informations. */
+ * gossip information. */
 void clusterSendPing(clusterLink *link, int type) {
     unsigned char *buf;
     clusterMsg *hdr;


### PR DESCRIPTION
fix typo in comment section of cluster.c 
information has no plural

[ci skip]