### PR TITLE
Fix text diff of large chunks to not emit last blank line

### DIFF
--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -23,7 +23,7 @@ sample_files/bad_combine_1.rs sample_files/bad_combine_2.rs
 f5051bf7d2b8afa3a677388cbd458891  -
 
 sample_files/big_text_hunk_1.txt sample_files/big_text_hunk_2.txt
-fd0c8912c094097f82c6b29ae66fb912  -
+fc26d41a5ff771670e04033b177973d2  -
 
 sample_files/change_outer_1.el sample_files/change_outer_2.el
 2b9334a4cc72da63bba28eff958f0038  -

--- a/src/line_parser.rs
+++ b/src/line_parser.rs
@@ -156,6 +156,9 @@ pub(crate) fn change_positions(lhs_src: &str, rhs_src: &str) -> Vec<MatchedPos> 
                 // individual words.
                 if lhs_words.len() > MAX_WORDS_IN_LINE || rhs_words.len() > MAX_WORDS_IN_LINE {
                     for lhs_pos in lhs_lp.from_region(lhs_offset, lhs_offset + lhs_part.len()) {
+                        if lhs_pos.start_col == lhs_pos.end_col {
+                            continue; // Omit last blank line
+                        }
                         mps.push(MatchedPos {
                             kind: MatchKind::NovelWord {
                                 highlight: TokenKind::Atom(AtomKind::Normal),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -50,6 +50,46 @@ fn inline() {
 }
 
 #[test]
+fn inline_big_text_hunk() {
+    let mut cmd = get_base_command();
+
+    cmd.arg("--display=inline")
+        .arg("sample_files/big_text_hunk_1.txt")
+        .arg("sample_files/big_text_hunk_2.txt");
+    cmd.assert().success();
+}
+
+#[test]
+fn side_by_side_big_text_hunk() {
+    let mut cmd = get_base_command();
+
+    cmd.arg("--display=side-by-side")
+        .arg("sample_files/big_text_hunk_1.txt")
+        .arg("sample_files/big_text_hunk_2.txt");
+    cmd.assert().success();
+}
+
+#[test]
+fn inline_many_newlines() {
+    let mut cmd = get_base_command();
+
+    cmd.arg("--display=inline")
+        .arg("sample_files/many_newlines_1.txt")
+        .arg("sample_files/many_newlines_2.txt");
+    cmd.assert().success();
+}
+
+#[test]
+fn side_by_side_many_newlines() {
+    let mut cmd = get_base_command();
+
+    cmd.arg("--display=side-by-side")
+        .arg("sample_files/many_newlines_1.txt")
+        .arg("sample_files/many_newlines_2.txt");
+    cmd.assert().success();
+}
+
+#[test]
 fn binary_changed() {
     let mut cmd = get_base_command();
 


### PR DESCRIPTION
~This fixes crash in inline printer, which assumes that hunk lines are within range. I'm not pretty sure if this assumption holds anytime, but myers_diff appears not emitting the last blank line, so I made the fall-back path do the same.~

~This will hopefully fix #702.~

myers_diff doesn't emit the last blank line, so I made the fall-back path do the same.

This was originally intended to fix #702, but fixes crash with `sample_files/big_text_hunk_?.txt` on 0.59.0. It probably fixes #739.