### PR TITLE
Add shell completions using clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +258,7 @@ dependencies = [
  "bumpalo",
  "cc",
  "clap",
+ "clap_complete",
  "crossterm",
  "encoding_rs",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ pkg-fmt = "zip"
 [dependencies]
 regex = "1.10.4"
 clap = { version = "4.0.0", features = ["cargo", "env", "wrap_help", "string"] }
+clap_complete = "4.5.67"
 typed-arena = "2.0.2"
 rustc-hash = "2.0.0"
 strsim = "0.11.0"

--- a/src/options.rs
+++ b/src/options.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
 use clap::{crate_authors, crate_description, value_parser, Arg, ArgAction, Command};
+use clap_complete::{generate, Shell};
 use crossterm::tty::IsTty;
 use owo_colors::OwoColorize as _;
 
@@ -361,6 +362,12 @@ Higher values will allow difftastic to perform a structural diff in more cases. 
                 .required(false),
         )
         .arg(
+            Arg::new("completion").long("completion")
+                 .value_name("SHELL")
+                 .value_parser(clap::value_parser!(Shell))
+                 .help("Generate completion for a given shell")
+        )
+        .arg(
             Arg::new("paths")
                 .value_name("PATHS")
                 .action(ArgAction::Append)
@@ -713,6 +720,12 @@ fn parse_binary_overrides_or_die(glob_strs: &[String]) -> Vec<glob::Pattern> {
 /// Parse CLI arguments passed to the binary.
 pub(crate) fn parse_args() -> Mode {
     let matches = app().get_matches();
+
+    if let Some(shell) = matches.get_one::<Shell>("completion") {
+        generate(*shell, &mut app(), "difft", &mut std::io::stdout());
+        // TODO: What should the exit code be? Should it be defined in src/exit_codes.rs
+        std::process::exit(0);
+    }
 
     let color_output = match matches
         .get_one::<String>("color")


### PR DESCRIPTION
This uses the last 3.x clap_complete version, which matches the currently used clap version (regarding MSRV).

Note the TODO I left, not sure what to do about that.