### PR TITLE
Update the cc package to 1.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ pretty_assertions = "1.3.0"
 [build-dependencies]
 # TODO: enable parallel mode once MSRV hits 1.61, see discussion in
 # https://github.com/rust-lang/cc-rs/pull/849
-cc = "1.0.83"
+cc = "1.1.5"
 rayon = "1.7.0"
 version_check = "0.9.4"
 


### PR DESCRIPTION
This includes the fix to https://github.com/rust-lang/cc-rs/issues/909 which spams warnings on ubuntu 22.04