### PR TITLE
Add Scoop installation instructions for Windows

### DIFF
--- a/demo_files/1/src/main.rs
+++ b/demo_files/1/src/main.rs
@@ -339,7 +339,7 @@ fn diff_file_content(
 /// incrementally.
 ///
 /// When more than one file is modified, the hg extdiff extension passes directory
-/// paths with the all the modified files.
+/// paths with all the modified files.
 fn diff_directories<'a>(
     lhs_dir: &'a Path,
     rhs_dir: &'a Path,

--- a/demo_files/2/src/main.rs
+++ b/demo_files/2/src/main.rs
@@ -341,7 +341,7 @@ fn diff_file_content(
 /// incrementally.
 ///
 /// When more than one file is modified, the hg extdiff extension passes directory
-/// paths with the all the modified files.
+/// paths with all the modified files.
 fn diff_directories<'a>(
     lhs_dir: &'a Path,
     rhs_dir: &'a Path,

--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -41,6 +41,13 @@ $ sudo pkg install difftastic
 ```
 
 If you're a Windows user, you can install
+[difftastic](https://scoop.sh/#/apps?q=difftastic)
+with `scoop`.
+```
+$ scoop install difftastic
+```
+
+If you're a Windows user, you can install
 [difftastic](https://community.chocolatey.org/packages/difftastic)
 with `choco`.
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -733,7 +733,7 @@ fn diff_file_content(
 /// incrementally.
 ///
 /// When more than one file is modified, the hg extdiff extension passes directory
-/// paths with the all the modified files.
+/// paths with all the modified files.
 fn diff_directories<'a>(
     lhs_dir: &'a Path,
     rhs_dir: &'a Path,

--- a/src/options.rs
+++ b/src/options.rs
@@ -260,7 +260,7 @@ When multiple overrides are specified, the first matching override wins."))
         )
         .arg(
             Arg::new("list-languages").long("list-languages")
-                .help("Print the all the languages supported by difftastic, along with their extensions.")
+                .help("Print all the languages supported by difftastic, along with their extensions.")
         )
         .arg(
             Arg::new("byte-limit").long("byte-limit")


### PR DESCRIPTION
Fix wording in the command-line help text as well as in some comments.