### PR TITLE
Include manpage in published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ include = [
         "/vendored_parsers/*-src/**/*.cc",
         "/LICENSE",
         "/README.md",
+        "/difft.1",
 ]
 
 [package.metadata.binstall]


### PR DESCRIPTION
```
$ cargo package --list --allow-dirty | grep difft
difft.1
```