### PR TITLE
Bump GitHub action workflows to their latest versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         run: rustup toolchain install stable --component llvm-tools-preview
@@ -16,7 +16,7 @@ jobs:
       - name: Generate code coverage
         run: cargo +stable llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,7 +22,7 @@ jobs:
     if: needs.pre_deploy.outputs.should_skip != 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install jq
         run: sudo apt-get install -y jq
@@ -31,9 +31,9 @@ jobs:
       - run: cargo doc
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: peaceiris/actions-mdbook@v2
         with:
-          mdbook-version: '0.4.34'
+          mdbook-version: '0.4.40'
 
       - name: Build manual
         run: mdbook build
@@ -53,7 +53,7 @@ jobs:
         run: cp -r homepage/* manual/book/
 
       - name: Deploy to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.6.4
         with:
           branch: gh-pages
           folder: manual/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   create-release:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
         with:
           # Create a draft release so we can add the changelog before publishing it
@@ -46,7 +46,7 @@ jobs:
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: difft
@@ -63,7 +63,7 @@ jobs:
   push_crates_io:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: katyo/publish-crates@v1
+      - uses: actions/checkout@v4
+      - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@1.65.0
@@ -65,7 +65,7 @@ jobs:
     name: Test with MIME database
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.65.0
       # This runs tests that rely on the MIME database being present.
       - run: cargo test -- --ignored
@@ -74,7 +74,7 @@ jobs:
     name: Test Linux (latest stable Rust)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo +stable test
 
@@ -82,7 +82,7 @@ jobs:
     name: Output Regression Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.65.0
       - name: Generate output for all sample files
         run: ./sample_files/compare_all.sh
@@ -93,7 +93,7 @@ jobs:
     name: Check Linux Packaging
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.65.0
       - run: cargo package --allow-dirty
 
@@ -101,7 +101,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.65.0
       - run: cargo fmt --all -- --check
 
@@ -109,7 +109,7 @@ jobs:
     name: Actionlint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: raven-actions/actionlint@v1
+      - uses: actions/checkout@v4
+      - uses: raven-actions/actionlint@v2
         with:
           shellcheck: false

--- a/manual/book.toml
+++ b/manual/book.toml
@@ -3,7 +3,7 @@ authors = ["Wilfred Hughes"]
 language = "en"
 src = "src"
 title = "Difftastic Manual"
-description = "The manual for difftastic, the structural dif tool"
+description = "The manual for difftastic, the structural diff tool"
 
 [output.html]
 git-repository-url = "https://github.com/wilfred/difftastic"

--- a/manual/src/tree_diffing.md
+++ b/manual/src/tree_diffing.md
@@ -32,7 +32,7 @@ Languages: [~10 programming
 languages](https://github.com/GumTreeDiff/gumtree/wiki/Languages)  
 Parser: Several, including [srcML](https://www.srcml.org/)  
 Algorithm: Top-down, then bottom-up  
-Ouput: HTML, Swing GUI, or text
+Output: HTML, Swing GUI, or text
 
 [GumTree](https://github.com/GumTreeDiff/gumtree) can parse several
 programming languages and then performs a tree-based diff, outputting
@@ -116,5 +116,3 @@ Output: CLI colours
 [Semantically meaningful S-expression diff: Tree-diff for lisp source
 code](https://archive.fosdem.org/2021/schedule/event/sexpressiondiff/)
 was presented at FOSDEM 2021.
-
-

--- a/src/parse/syntax.rs
+++ b/src/parse/syntax.rs
@@ -1103,7 +1103,7 @@ mod tests {
         }
     }
 
-    /// Ignore the syntax highighting kind when comparing
+    /// Ignore the syntax highlighting kind when comparing
     /// atoms. Sometimes changing delimiter wrapping can change
     /// whether a parser thinks that a node is e.g. a type.
     #[test]

--- a/translation/zh-CN/manual-zh-CN/book.toml
+++ b/translation/zh-CN/manual-zh-CN/book.toml
@@ -3,7 +3,7 @@ authors = ["Wilfred Hughes"]
 language = "zh-CN"
 src = "src"
 title = "Difftastic Manual"
-description = "The manual for difftastic, the structural dif tool"
+description = "The manual for difftastic, the structural diff tool"
 
 [output.html]
 git-repository-url = "https://github.com/wilfred/difftastic"


### PR DESCRIPTION
This PR bumps GitHub action workflows to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/Wilfred/difftastic/actions/runs/10715614378).
This PR also fixes a few typos on the way.