### PR TITLE
Atomize hex and unicode string literals in Solidity

### DIFF
--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -1045,7 +1045,9 @@ pub(crate) fn from_language(language: guess::Language) -> TreeSitterConfig {
             let language = unsafe { tree_sitter_solidity() };
             TreeSitterConfig {
                 language,
-                atom_nodes: vec!["string"].into_iter().collect(),
+                atom_nodes: vec!["string", "hex_string_literal", "unicode_string_literal"]
+                    .into_iter()
+                    .collect(),
                 delimiter_tokens: vec![("[", "]"), ("(", ")"), ("{", "}")],
                 highlight_query: ts::Query::new(
                     language,


### PR DESCRIPTION
Without this, changes inside these string types are not taken into consideration when performing the diff.