### PR TITLE
docs(contributing): Add mdbook install note about toolchain

### DIFF
--- a/manual/src/contributing.md
+++ b/manual/src/contributing.md
@@ -30,6 +30,8 @@ This website is generated with
 [mdbook](https://github.com/rust-lang/mdBook/). mdbook can be
 installed with Cargo.
 
+*Note: difftastic uses an older Rust toolchain version. You have to run `cargo install mdbook` outside of the repository directory. Otherwise, installation fails.*
+
 ```
 $ cargo install mdbook
 ```


### PR DESCRIPTION
The difftastic `Cargo.toml` currently specifies Rust version 1.66 to be used.

When running `cargo install mdbook` in the repository directory or manual sub-directory, the installation fails.

With a more recent Rust toolchain active, which can reasonably be assumed outside of the repository directory, the mdbook installation works fine.

If the user does not have a more recent toolchain active outside of the directory, the note at least serves as a pointer to the issue.

---

The error in question:

```
error: failed to compile `mdbook v0.4.40`, intermediate artifacts can be found at `[…]\Temp\cargo-install[…]`

Caused by:
  failed to select a version for `env_logger`.
      ... required by package `mdbook v0.4.40`
  versions that meet the requirements `^0.11.1` are: 0.11.5, 0.11.4, 0.11.3, 0.11.2, 0.11.1

  the package `mdbook` depends on `env_logger`, with features: `anstream` but `env_logger` does not have these features.
   It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.

  failed to select a version for `env_logger` which could resolve this conflict
```