### PR TITLE
Avoid random ordering of lines in JSON output.

### DIFF
--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -150,7 +150,12 @@ impl<'f> From<&'f DiffResult> for File<'f> {
                         }
                     }
 
-                    chunks.push(lines.into_values().collect());
+                    chunks.push(
+                        aligned_lines
+                            .iter()
+                            .filter_map(|(l, r)| lines.remove(&(l.map(|l| l.0), r.map(|r| r.0))))
+                            .collect(),
+                    );
                 }
 
                 File::with_sections(&summary.file_format, &summary.display_path, chunks)


### PR DESCRIPTION
Pretty much what it says on the tin.

As the lines are stored in a HashMap, calling `into_values()` gives us a random order of lines.
My solution here is definitely not pretty but was the simplest thing that worked without putting too much thought into the code. I hope thats fine. And thank you for the tool :)