### PR TITLE
Stop using deprecated macos-12 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,13 @@ jobs:
         job:
           # Operating systems available: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          # mac-latest (currently mac-14) is an ARM device, so use macos-12 to get Intel.
-          # Update annoucement: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
-          - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
 
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
 
-          # mac-14 is an M1 ARM device.
+          # macos-14 is an M1 ARM device but macos-14 is x86-64
+          # https://github.com/actions/runner-images
+          - { target: x86_64-apple-darwin, os: macos-14-large }
           - { target: aarch64-apple-darwin, os: macos-14 }
 
           # musl binaries produced by GitHub actions segfault when run, see


### PR DESCRIPTION
The `macos-12` runner is [deprecated](https://github.com/actions/runner-images/issues/10721) and causing pipelines to fail.

This PR updates it to `macos-14-large` which is still [Intel-based](https://github.com/actions/runner-images).