### PR TITLE
Avoid race condition

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -249,7 +249,7 @@ fn main() {
         println!("cargo:rerun-if-changed={}", parser.src_dir);
     }
 
-    parsers.par_iter().for_each(|p| p.build());
+    parsers.iter().for_each(|p| p.build());
     commit_info();
 
     if let Some((version, _, _)) = rustc::triple() {


### PR DESCRIPTION
There seems to be some race-condition in `build.rs`
that causes random build results to be produced for `/usr/bin/difft`.

This change seems to have negligible influence on overall build time.

If you make a better patch, I can test it.