### PR TITLE
Upgrade a number of dependencies across SemVer boundaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,9 +628,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,18 +930,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "hashbrown",
  "humansize",
  "ignore",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "lazy_static",
  "libc",
  "libmimalloc-sys",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -271,7 +271,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "streaming-iterator",
- "strsim 0.10.0",
+ "strsim",
  "strum",
  "tree-sitter",
  "tree-sitter-bash",
@@ -921,12 +921,6 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,7 +237,7 @@ dependencies = [
  "crossterm",
  "encoding_rs",
  "glob",
- "hashbrown",
+ "hashbrown 0.15.2",
  "humansize",
  "ignore",
  "itertools 0.14.0",
@@ -385,6 +373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,12 +399,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -463,7 +464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1564,23 +1565,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "line-numbers"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b25f5068853805faa3c19f44d0c401446e4eb3f47cc808fa331eec30f0ba35c"
+checksum = "24ab6409a2f9ffae158ae823a012a7d7d68386663a14bedc260ca66eacf65c2c"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ hashbrown = "0.15.1"
 humansize = "2.1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-line-numbers = "0.3.0"
+line-numbers = "0.4.0"
 smallvec = "1.13.2"
 tree-sitter-language = "0.1.3"
 streaming-iterator = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ clap = { version = "4.0.0", features = ["cargo", "env", "wrap_help", "string"] }
 itertools = "0.14.0"
 typed-arena = "2.0.2"
 rustc-hash = "2.0.0"
-strsim = "0.10.0"
+strsim = "0.11.1"
 lazy_static = "1.4.0"
 tree-sitter = "0.24.0"
 libc = "0.2.108"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ radix-heap = "0.4.2"
 # a slightly more aggressive MSRV than difftastic. Constrain ignore to
 # a known-good max version.
 ignore = ">= 0.4, < 0.4.24"
-owo-colors = "3.5.0"
+owo-colors = "4.2.0"
 wu-diff = "0.1.2"
 rayon = "1.7.0"
 tree_magic_mini = "3.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ bumpalo = "3.16.0"
 unicode-width = "0.1.9"
 crossterm = { version = "0.28.0", features = ["windows"] }
 glob = "0.3.1"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 hashbrown = "0.14.0"
 humansize = "2.1.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ unicode-width = "0.1.9"
 crossterm = { version = "0.28.0", features = ["windows"] }
 glob = "0.3.1"
 strum = { version = "0.27", features = ["derive"] }
-hashbrown = "0.14.0"
+hashbrown = "0.15.1"
 humansize = "2.1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pkg-fmt = "zip"
 [dependencies]
 regex = "1.10.4"
 clap = { version = "4.0.0", features = ["cargo", "env", "wrap_help", "string"] }
-itertools = "0.11.0"
+itertools = "0.14.0"
 typed-arena = "2.0.2"
 rustc-hash = "2.0.0"
 strsim = "0.10.0"


### PR DESCRIPTION
Update itertools, strsim, owo-colors, strum, hashbrown, and line-numbers to current releases. In all cases, the upstream changelog is linked in the commit message (except owo-colors where none is available), I inspected the source for obvious issues, and I confirmed that `cargo test` still works.

I did not touch `unicode-width` or any of the `tree-sitter` crates because I suspected that those updates might require more careful validation.