### PR TITLE
ci: build & test for aarch64-pc-windows-msvc target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       # v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           # mac-latest (currently mac-14) is an ARM device, so use macos-13 to get Intel.
           - { target: x86_64-apple-darwin, os: macos-13 }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { target: aarch64-pc-windows-msvc, os: windows-latest }
 
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           # mac-latest (currently mac-14) is an ARM device, so use macos-13 to get Intel.
           - { target: x86_64-apple-darwin, os: macos-13 }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
-          - { target: aarch64-pc-windows-msvc, os: windows-latest }
+          - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
 
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
 


### PR DESCRIPTION
I have tested [the binary](https://github.com/Master-Hash/difftastic/releases/tag/0.65.0) on my machine. All CI tests pass. 

I don't think the code need modification, and hopefully I modified all the CI script needed.