### PR TITLE
Recommend file-by-file mode for Jujutsu config

### DIFF
--- a/manual/src/jj.md
+++ b/manual/src/jj.md
@@ -9,7 +9,9 @@ file](https://jj-vcs.github.io/jj/latest/config/#user-config-files).
 
 ```toml
 [ui]
-diff-formatter = ["difft", "--color=always", "$left", "$right"]
+diff.tool = "difft"
+
+[merge-tools.difft]
+diff-args = ["--color=always", "$left", "$right"]
+diff-invocation-mode = "file-by-file"
 ```
-
-


### PR DESCRIPTION
The previous docs gave difft two directories to diff.  But that loses information about file renames, which is information jj has.

This configuration tells Jujutsu to pass individual pairs of files to difft.