### PR TITLE
Fix GitHub logo reflow

### DIFF
--- a/homepage/home_static/style.css
+++ b/homepage/home_static/style.css
@@ -69,7 +69,8 @@ a {
 }
 
 .github-logo {
-  padding-right: 5px;
+  margin-right: 5px;
+  pointer-events: none;
 }
 
 .card-set .card {

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -51,6 +51,8 @@
             role="button"
             ><object
               class="github-logo"
+              width="16"
+              height="16"
               data="home_img/github.svg"
               type="image/svg+xml"
             ></object>


### PR DESCRIPTION
- Set a fixed width on the GitHub logo to prevent reflow while loading
- Set `pointer-events: none;` so clicking the logo still links correctly

https://github.com/user-attachments/assets/68e942d9-4a5b-4cb1-b063-954b25329787

https://github.com/user-attachments/assets/90f88fc7-3ea5-4e19-8066-5f3641e6037f