### PR TITLE
escape quotes

### DIFF
--- a/manual/src/git.md
+++ b/manual/src/git.md
@@ -112,7 +112,7 @@ To define a difftool named `difftastic`, add the following to your
 ```ini
 [difftool "difftastic"]
     # See `man git-difftool` for a description of MERGED, LOCAL and REMOTE.
-    cmd = difft "$MERGED" "$LOCAL" "abcdef1" "100644" "$REMOTE" "abcdef2" "100644"
+    cmd = difft \"$MERGED\" \"$LOCAL\" \"abcdef1\" \"100644\" \"$REMOTE\" \"abcdef2\" \"100644\"
 ```
 
 You can now use difftastic as a difftool:


### PR DESCRIPTION
I had no luck with these unescaped quotes; if added to the config via `git config` they likely get escaped automatically, but if done so directly in git's config file they seem to need escaping