### PR TITLE
Do not use jemalloc on illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ tree-sitter-xml = "0.7.0"
 tree-sitter-yaml = "0.7.0"
 tree-sitter-zig = "1.1.2"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "illumos")))'.dependencies]
 tikv-jemallocator = "0.6"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,10 @@ use crate::parse::syntax;
 ///
 /// For reference, Jemalloc uses 10-20% more time (although up to 33%
 /// more instructions) when testing on sample files.
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "illumos")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "illumos")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
This is a minor portability fix.

jemalloc does not work on illumos, but fortunately, its use within difftastic is already conditional on the target environment not being msvc, so simply extend that conditional involved to also exclude illumos.