### PR TITLE
Do not use jemalloc on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ tree-sitter-xml = "0.7.0"
 tree-sitter-yaml = "0.7.0"
 tree-sitter-zig = "1.1.2"
 
-[target.'cfg(not(any(target_env = "msvc", target_os = "illumos")))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))'.dependencies]
 tikv-jemallocator = "0.6"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,10 @@ use crate::parse::syntax;
 ///
 /// For reference, Jemalloc uses 10-20% more time (although up to 33%
 /// more instructions) when testing on sample files.
-#[cfg(not(any(target_env = "msvc", target_os = "illumos")))]
+#[cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "illumos")))]
+#[cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
FreeBSD uses jemalloc anyway, and tikv_jemallocator does not build.