### PR TITLE
Add metadata to allow fast create .deb package with "cargo deb" command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,4 +151,14 @@ lto = "thin"
 name = "difft"
 path = "src/main.rs"
 
+[package.metadata.deb]
+depends = "$auto"
+section = "utility"
+priority = "optional"
+assets = [
+	"$auto",
+	[ "difft.1", "usr/share/man/man1/", "644" ],
+	[ "CHANGELOG.md", "usr/share/doc/difftastic/", "644" ],
+]
+
 [features]


### PR DESCRIPTION
With this metadata it's easy to create .deb file easy — just `cargo deb`.