### PR TITLE
Fix issue 934 in difftastic

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,7 +17,7 @@ fn find_runner() -> Option<String> {
 // cross-compiled binaries.
 fn get_base_command() -> Command {
     let mut cmd;
-    let path = assert_cmd::cargo::cargo_bin("difft");
+    let path = assert_cmd::cargo::cargo_bin!("difft");
     if let Some(runner) = find_runner() {
         let mut runner = runner.split_whitespace();
         cmd = Command::new(runner.next().unwrap());


### PR DESCRIPTION
Replace deprecated assert_cmd::cargo::cargo_bin() function with cargo_bin!() macro to avoid relying on Cargo implementation details that will break in future versions.

Fixes #934