### PR TITLE
Add `aligned_lines` field to JSON

### DIFF
--- a/src/display/json.rs
+++ b/src/display/json.rs
@@ -194,9 +194,8 @@ impl Serialize for File<'_> {
         // Count fields: language, path, status are always present (3)
         // + aligned_lines if not empty (1)
         // + chunks if not empty (1)
-        let field_count = 3
-            + (!self.aligned_lines.is_empty()) as usize
-            + (!self.chunks.is_empty()) as usize;
+        let field_count =
+            3 + (!self.aligned_lines.is_empty()) as usize + (!self.chunks.is_empty()) as usize;
 
         let mut file = serializer.serialize_struct("File", field_count)?;
 


### PR DESCRIPTION
## Overview

Add an `aligned_lines` field to the JSON output that exposes the line alignment computed by `all_matched_lines_filled()`. This enables consumers to display side-by-side diffs with correct alignment without having to reverse-engineer the alignment from the chunks.

Each entry in `aligned_lines` is a pair `[lhs_line, rhs_line]` where either value may be null (indicating a filler line on that side).

For context, I'm writing a neovim plugin for `difftastic` where I'd like to render the diff in a vertical split, and this simplifies the rendering logic a great deal.