### PR TITLE
don't use jemalloc for Windows targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ tree-sitter-xml = "0.7.0"
 tree-sitter-yaml = "0.7.0"
 tree-sitter-zig = "1.1.2"
 
-[target.'cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))'.dependencies]
+[target.'cfg(not(any(windows, target_os = "illumos", target_os = "freebsd")))'.dependencies]
 tikv-jemallocator = "0.6"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,10 +98,10 @@ use crate::parse::syntax;
 ///
 /// For reference, Jemalloc uses 10-20% more time (although up to 33%
 /// more instructions) when testing on sample files.
-#[cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))]
+#[cfg(not(any(windows, target_os = "illumos", target_os = "freebsd")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "illumos", target_os = "freebsd")))]
+#[cfg(not(any(windows, target_os = "illumos", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
I tried to add difftastic package in https://github.com/msys2/MINGW-packages/pull/27535, but I didn't manage to get successful build of jemalloc-sys on windows-gnu. I'll try to investigate it later, for now I suggest to just not use jemalloc for all Windows targets