### PR TITLE
fix: don't count javascript template strings as atoms

### DIFF
--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -593,7 +593,7 @@ pub(crate) fn from_language(language: guess::Language) -> TreeSitterConfig {
 
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["string", "template_string", "regex"].into_iter().collect(),
+                atom_nodes: ["string", "regex"].into_iter().collect(),
                 delimiter_tokens: vec![
                     ("[", "]"),
                     ("(", ")"),
@@ -1072,7 +1072,7 @@ pub(crate) fn from_language(language: guess::Language) -> TreeSitterConfig {
 
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["string", "template_string"].into_iter().collect(),
+                atom_nodes: ["string"].into_iter().collect(),
                 delimiter_tokens: vec![("{", "}"), ("(", ")"), ("[", "]"), ("<", ">")],
                 highlight_query: ts::Query::new(&language, &highlight_query).unwrap(),
                 sub_languages: vec![],
@@ -1087,9 +1087,7 @@ pub(crate) fn from_language(language: guess::Language) -> TreeSitterConfig {
 
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["string", "template_string", "regex", "predefined_type"]
-                    .into_iter()
-                    .collect(),
+                atom_nodes: ["string", "regex", "predefined_type"].into_iter().collect(),
                 delimiter_tokens: vec![("{", "}"), ("(", ")"), ("[", "]"), ("<", ">")],
                 highlight_query: ts::Query::new(&language, &highlight_query).unwrap(),
                 sub_languages: vec![],
@@ -1835,7 +1833,7 @@ fn atom_from_cursor<'a>(
         AtomKind::Comment
     } else if highlights.keyword_ids.contains(&node.id()) {
         AtomKind::Keyword
-    } else if highlights.string_ids.contains(&node.id()) {
+    } else if node.kind() == "string_fragment" || highlights.string_ids.contains(&node.id()) {
         AtomKind::String(StringKind::StringLiteral)
     } else if highlights.type_ids.contains(&node.id()) {
         AtomKind::Type


### PR DESCRIPTION
if template strings are atoms, changing the indentation of a block of code containing one counts that as a change, which is bad. instead, recurse the expression as normal.

not very happy with adding a special case to `atom_from_cursor` but i'm not familiar enough to know the right strategy.

test case
```ts
let x = `hello ${y
  ? 1
  : 2
}`;
```
```ts
{
  let x = `hello ${y
    ? 1
    : 2
  }`;
}
```