### PR TITLE
Add AL (Business Central) language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "tikv-jemallocator",
  "tree-sitter",
  "tree-sitter-ada",
+ "tree-sitter-al",
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
@@ -1031,6 +1032,16 @@ name = "tree-sitter-ada"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9fcdd64359c98fcc99d72f6d3d6ca5d6d76ce325ac39430b1d283a0fb61ca1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-al"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4fa52cb7019d81f6aeb3c057e4774ffea25a4b89a5c6f3d7cf47bca100bb930"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tree-sitter-language = "0.1.3"
 
 # tree-sitter parsers that are available on crates.io.
 tree-sitter-ada = "0.1.0"
+tree-sitter-al = "2.3.0"
 tree-sitter-bash = "0.25.1"
 tree-sitter-c = "0.24"
 tree-sitter-c-sharp = "0.23.1"

--- a/sample_files/al_1.al
+++ b/sample_files/al_1.al
@@ -1,0 +1,40 @@
+codeunit 6175305 "CDO Issue Document"
+{
+    // C/SIDE
+    // revision:5
+
+
+    trigger OnRun()
+    begin
+    end;
+
+    procedure IssueReminder(ReminderHeader: Record "Reminder Header")
+    var
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        DocumentOutput: Codeunit "CDO E-Mail Handler";
+        ReminderIssue: Codeunit "Reminder-Issue";
+    begin
+        ReminderHeader.SETRECFILTER;
+        ReminderIssue.Set(ReminderHeader, false, 0D);
+        ReminderIssue.RUN;
+
+        ReminderIssue.GetIssuedReminder(IssuedReminderHeader);
+        IssuedReminderHeader.SETRECFILTER;
+        DocumentOutput.DocHandle(false, IssuedReminderHeader, IssuedReminderHeader.FIELDNO("Language Code"), IssuedReminderHeader.GETVIEW(true));
+    end;
+
+    procedure IssueFinanceChargeMemo(FinanceChargeMemoHeader: Record "Finance Charge Memo Header")
+    var
+        IssuedFinChargeMemoHeader: Record "Issued Fin. Charge Memo Header";
+        DocumentOutput: Codeunit "CDO E-Mail Handler";
+        FinChrgMemoIssue: Codeunit "FinChrgMemo-Issue";
+    begin
+        FinanceChargeMemoHeader.SETRECFILTER;
+        FinChrgMemoIssue.Set(FinanceChargeMemoHeader, false, 0D);
+        FinChrgMemoIssue.RUN;
+
+        FinChrgMemoIssue.GetIssuedFinChrgMemo(IssuedFinChargeMemoHeader);
+        IssuedFinChargeMemoHeader.SETRECFILTER;
+        DocumentOutput.DocHandle(false, IssuedFinChargeMemoHeader, IssuedFinChargeMemoHeader.FIELDNO("Language Code"), IssuedFinChargeMemoHeader.GETVIEW(true));
+    end;
+}

--- a/sample_files/al_2.al
+++ b/sample_files/al_2.al
@@ -1,0 +1,43 @@
+codeunit 6175305 "CDO Issue Document"
+{
+    // C/SIDE
+    // revision:6
+
+
+    trigger OnRun()
+    begin
+    end;
+
+    procedure IssueReminder(ReminderHeader: Record "Reminder Header")
+    var
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        DocumentOutput: Codeunit "CDO E-Mail Handler";
+        ReminderIssue: Codeunit "Reminder-Issue";
+        IsSuccess: Boolean;
+    begin
+        ReminderHeader.SETRECFILTER;
+        ReminderIssue.Set(ReminderHeader, false, 0D);
+        IsSuccess := ReminderIssue.RUN;
+
+        if IsSuccess then begin
+            ReminderIssue.GetIssuedReminder(IssuedReminderHeader);
+            IssuedReminderHeader.SETRECFILTER;
+            DocumentOutput.DocHandle(false, IssuedReminderHeader, IssuedReminderHeader.FIELDNO("Language Code"), IssuedReminderHeader.GETVIEW(true));
+        end;
+    end;
+
+    procedure IssueFinanceChargeMemo(FinanceChargeMemoHeader: Record "Finance Charge Memo Header")
+    var
+        IssuedFinChargeMemoHeader: Record "Issued Fin. Charge Memo Header";
+        DocumentOutput: Codeunit "CDO E-Mail Handler";
+        FinChrgMemoIssue: Codeunit "FinChrgMemo-Issue";
+    begin
+        FinanceChargeMemoHeader.SETRECFILTER;
+        FinChrgMemoIssue.Set(FinanceChargeMemoHeader, false, 0D);
+        FinChrgMemoIssue.RUN;
+
+        FinChrgMemoIssue.GetIssuedFinChrgMemo(IssuedFinChargeMemoHeader);
+        IssuedFinChargeMemoHeader.SETRECFILTER;
+        DocumentOutput.DocHandle(false, IssuedFinChargeMemoHeader, IssuedFinChargeMemoHeader.FIELDNO("Language Code"), IssuedFinChargeMemoHeader.GETVIEW(true));
+    end;
+}

--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -7,6 +7,9 @@ sample_files/ada_1.adb sample_files/ada_2.adb
 sample_files/added_line_1.txt sample_files/added_line_2.txt
 8a1587e6b5fc53f2ec2ac665a5d00372  -
 
+sample_files/al_1.al sample_files/al_2.al
+b67012a6fe866337a9b9eaea4afa86a5  -
+
 sample_files/align_footer_1.txt sample_files/align_footer_2.txt
 49b8e5156047150594abbab22c402efa  -
 

--- a/src/parse/guess_language.rs
+++ b/src/parse/guess_language.rs
@@ -20,6 +20,7 @@ use strum::{EnumIter, IntoEnumIterator};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub(crate) enum Language {
     Ada,
+    Al,
     Apex,
     Bash,
     C,
@@ -122,6 +123,7 @@ pub(crate) fn language_override_from_name(name: &str) -> Option<LanguageOverride
 pub(crate) fn language_name(language: Language) -> &'static str {
     match language {
         Ada => "Ada",
+        Al => "AL",
         Apex => "Apex",
         Bash => "Bash",
         C => "C",
@@ -198,6 +200,7 @@ use crate::lines::split_on_newlines;
 pub(crate) fn language_globs(language: Language) -> Vec<glob::Pattern> {
     let glob_strs: &'static [&'static str] = match language {
         Ada => &["*.ada", "*.adb", "*.ads"],
+        Al => &["*.al"],
         Bash => &[
             "*.bash",
             "*.bats",

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -110,6 +110,31 @@ pub(crate) fn from_language(language: guess::Language) -> TreeSitterConfig {
                 sub_languages: vec![],
             }
         }
+        Al => {
+            let language_fn = tree_sitter_al::LANGUAGE;
+            let language = tree_sitter::Language::new(language_fn);
+            TreeSitterConfig {
+                language: language.clone(),
+                atom_nodes: [
+                    "string_literal",
+                    "integer",
+                    "decimal",
+                    "boolean",
+                    "date_literal",
+                    "time_literal",
+                    "datetime_literal",
+                    "biginteger_literal",
+                    "identifier",
+                    "quoted_identifier",
+                ]
+                .into_iter()
+                .collect(),
+                delimiter_tokens: vec![("{", "}"), ("(", ")"), ("[", "]")],
+                highlight_query: ts::Query::new(&language, tree_sitter_al::HIGHLIGHTS_QUERY)
+                    .unwrap(),
+                sub_languages: vec![],
+            }
+        }
         Apex => {
             let language_fn = tree_sitter_sfapex::apex::LANGUAGE;
             let language = tree_sitter::Language::new(language_fn);


### PR DESCRIPTION
## Summary
- Add tree-sitter-al parser (crate v2.3.0 from crates.io) for AL language support
- AL is the programming language used for Microsoft Dynamics 365 Business Central
- Detects `.al` files, includes syntax highlighting via the crate's built-in HIGHLIGHTS_QUERY