### PR TITLE
Fix hunk alignment for inline display

### DIFF
--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -6,7 +6,7 @@ use crate::display::context::{
 };
 use crate::display::hunks::Hunk;
 use crate::display::style::{self, apply_colors, apply_line_number_color};
-use crate::lines::{format_line_num, split_on_newlines, MaxLine};
+use crate::lines::{format_line_num, format_line_num_padded, split_on_newlines, MaxLine};
 use crate::options::DisplayOptions;
 use crate::parse::syntax::MatchedPos;
 use crate::summary::FileFormat;
@@ -64,6 +64,10 @@ pub(crate) fn print(
     let opposite_to_lhs = opposite_positions(lhs_mps);
     let opposite_to_rhs = opposite_positions(rhs_mps);
 
+    // Calculate the maximum line number width for alignment
+    let lhs_line_nums_width = format_line_num(lhs_src.max_line()).len();
+    let rhs_line_nums_width = format_line_num(rhs_src.max_line()).len();
+
     for (i, hunk) in hunks.iter().enumerate() {
         println!(
             "{}",
@@ -100,7 +104,7 @@ pub(crate) fn print(
                 print!(
                     "{}   {}",
                     apply_line_number_color(
-                        &format_line_num(lhs_line),
+                        &format_line_num_padded(lhs_line, lhs_line_nums_width),
                         false,
                         Side::Left,
                         display_options,
@@ -115,7 +119,7 @@ pub(crate) fn print(
                 print!(
                     "{}   {}",
                     apply_line_number_color(
-                        &format_line_num(*lhs_line),
+                        &format_line_num_padded(*lhs_line, lhs_line_nums_width),
                         true,
                         Side::Left,
                         display_options,
@@ -129,7 +133,7 @@ pub(crate) fn print(
                 print!(
                     "   {}{}",
                     apply_line_number_color(
-                        &format_line_num(*rhs_line),
+                        &format_line_num_padded(*rhs_line, rhs_line_nums_width),
                         true,
                         Side::Right,
                         display_options,
@@ -144,7 +148,7 @@ pub(crate) fn print(
                 print!(
                     "   {}{}",
                     apply_line_number_color(
-                        &format_line_num(*rhs_line),
+                        &format_line_num_padded(*rhs_line, rhs_line_nums_width),
                         false,
                         Side::Right,
                         display_options,

--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -13,21 +13,13 @@ use crate::display::style::{
     split_and_apply, width_respecting_tabs, BackgroundColor,
 };
 use crate::hash::{DftHashMap, DftHashSet};
-use crate::lines::{format_line_num, split_on_newlines};
+use crate::lines::{format_line_num, format_line_num_padded, split_on_newlines};
 use crate::options::{DisplayMode, DisplayOptions};
 use crate::parse::syntax::{zip_pad_shorter, MatchedPos};
 use crate::summary::FileFormat;
 
 /// The space shown between LHS and RHS columns.
 const SPACER: &str = "  ";
-
-fn format_line_num_padded(line_num: LineNumber, column_width: usize) -> String {
-    format!(
-        "{:width$} ",
-        line_num.as_usize() + 1,
-        width = column_width - 1
-    )
-}
 
 fn format_missing_line_num(
     prev_num: LineNumber,

--- a/src/lines.rs
+++ b/src/lines.rs
@@ -8,6 +8,14 @@ pub(crate) fn format_line_num(line_num: LineNumber) -> String {
     format!("{} ", line_num.display())
 }
 
+pub(crate) fn format_line_num_padded(line_num: LineNumber, column_width: usize) -> String {
+    format!(
+        "{:width$} ",
+        line_num.as_usize() + 1,
+        width = column_width - 1
+    )
+}
+
 /// Return the length of `s` in bytes.
 ///
 /// This is a trivial wrapper to make it clear when we want bytes not


### PR DESCRIPTION
Hello there 👋🏻 


The side-by-side displays use padding to align the line numbers of hunks, but the inline display did not. For a hunk that has line numbers transitioning to a higher order (e.g. lines 7-12, or 97-102), the file contents would end up misaligned by that one character difference.

To highlight the issue, here is a pair of plain text files.

```
[…/difftastic][01:55:28] > cat /tmp/test_left.txt
line D7037CABD97774A05FFCD38194093BFF
line 9E5441F1DD1FE52F1F5B5C73E853CC41
line 4624B6E1A7C2F94CE15D48E626AAA8C1
line C0673AF915DA0160838EBDBD95D2D32A
line 4DC6E37409A4EEC157F5A48DF044AEAE
line B6ADCBE985C6202E14AC388DA47D2C73
line 0ABAD62A62ABD2E2E220ED4BEC0D877D
line 4ED1B7FCDBA4BF863F47482A435A6FAB
line 84824623A6A4BF3A06715FCBB63585F5
line 4C827495A0D45CDC5FD1D400A641690B
line E80F6B161B2A7523FB5AFE053D24C217
line 4DAA9AE6CC0CAB9E0E0E369B77D2FCE2
line F496281D9F0B78EEDB4245DE0AEFC800

[…/difftastic][01:55:34] > cat /tmp/test_right.txt
line D7037CABD97774A05FFCD38194093BFF
line 9E5441F1DD1FE52F1F5B5C73E853CC41
line 4624B6E1A7C2F94CE15D48E626AAA8C1
line C0673AF915DA0160838EBDBD95D2D32A
line 4DC6E37409A4EEC157F5A48DF044AEAE
line B6ADCBE985C6202E14AC388DA47D2C73
line 0ABAD62A62ABD2E2E220ED4BEC0D877D
line 4ED1B7FCDBA4BF863F47482A435A6FAB modified
line 84824623A6A4BF3A06715FCBB63585F5 modified
line 4C827495A0D45CDC5FD1D400A641690B modified
line E80F6B161B2A7523FB5AFE053D24C217
line 4DAA9AE6CC0CAB9E0E0E369B77D2FCE2
line F496281D9F0B78EEDB4245DE0AEFC800
```

And here's what the inline diff looks like with the latest release of `difftastic`:
```
[…/difftastic][01:56:23] > difft --display=inline /tmp/test_left.txt /tmp/test_right.txt
/tmp/test_right.txt --- Text
4    line C0673AF915DA0160838EBDBD95D2D32A
5    line 4DC6E37409A4EEC157F5A48DF044AEAE
6    line B6ADCBE985C6202E14AC388DA47D2C73
7    line 0ABAD62A62ABD2E2E220ED4BEC0D877D
8    line 4ED1B7FCDBA4BF863F47482A435A6FAB
9    line 84824623A6A4BF3A06715FCBB63585F5
10    line 4C827495A0D45CDC5FD1D400A641690B
   8 line 4ED1B7FCDBA4BF863F47482A435A6FAB modified
   9 line 84824623A6A4BF3A06715FCBB63585F5 modified
   10 line 4C827495A0D45CDC5FD1D400A641690B modified
   11 line E80F6B161B2A7523FB5AFE053D24C217
   12 line 4DAA9AE6CC0CAB9E0E0E369B77D2FCE2
   13 line F496281D9F0B78EEDB4245DE0AEFC800
```

This commit re-uses the padding logic of the side-by-side displays in the inline display to fix that weird alignment.
```
[…/difftastic][01:59:47] > ./target/release/difft --display=inline /tmp/test_left.txt /tmp/test_right.txt
/tmp/test_right.txt --- Text
 4    line C0673AF915DA0160838EBDBD95D2D32A
 5    line 4DC6E37409A4EEC157F5A48DF044AEAE
 6    line B6ADCBE985C6202E14AC388DA47D2C73
 7    line 0ABAD62A62ABD2E2E220ED4BEC0D877D
 8    line 4ED1B7FCDBA4BF863F47482A435A6FAB
 9    line 84824623A6A4BF3A06715FCBB63585F5
10    line 4C827495A0D45CDC5FD1D400A641690B
    8 line 4ED1B7FCDBA4BF863F47482A435A6FAB modified
    9 line 84824623A6A4BF3A06715FCBB63585F5 modified
   10 line 4C827495A0D45CDC5FD1D400A641690B modified
   11 line E80F6B161B2A7523FB5AFE053D24C217
   12 line 4DAA9AE6CC0CAB9E0E0E369B77D2FCE2
   13 line F496281D9F0B78EEDB4245DE0AEFC800
```

I'm not sure if this fixes any specific issues. I've looked through a bunch that mention the inline display mode, none of them seem to identify that specific problem. But it has been annoying me for a while and I figured it was time to offer a fix. 😅