### PR TITLE
fix(files): use display_path for DFT_OVERRIDE_BINARY matching (closes #967)

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -149,13 +149,12 @@ pub(crate) enum ProbableFileKind {
 /// <https://git-scm.com/docs/gitattributes#_working_tree_encoding>
 pub(crate) fn guess_content(
     bytes: &[u8],
-    path: &FileArgument,
+    display_path: &str,
     binary_overrides: &[glob::Pattern],
 ) -> ProbableFileKind {
-    if let FileArgument::NamedPath(path) = path {
-        let path = path.to_string_lossy();
+    if !display_path.is_empty() {
         for pattern in binary_overrides {
-            if pattern.matches(&path) {
+            if matches_override(pattern, display_path) {
                 info!(
                     "Input file is treated as binary due to explicit override glob {}",
                     pattern
@@ -354,12 +353,34 @@ pub(crate) fn relative_paths_in_either(lhs_dir: &Path, rhs_dir: &Path) -> Vec<Pa
     paths
 }
 
+/// Returns `true` if `pattern` matches `display_path`, either as the
+/// full path or as the bare basename.
+///
+/// Glob's default semantics treat `*` as not crossing `/`, so `*.gz`
+/// would only match files at the root of the diff. Users supplying
+/// `DFT_OVERRIDE_BINARY=*.gz` reasonably expect it to match `.gz` files
+/// at any depth, mirroring how `.gitignore` treats patterns without an
+/// explicit slash. We keep the path-shaped match for patterns that *do*
+/// contain a slash (`build/*.lock`) and add the basename match for the
+/// "file-extension" shape that's by far the more common usage of this
+/// env var.
+fn matches_override(pattern: &glob::Pattern, display_path: &str) -> bool {
+    if pattern.matches(display_path) {
+        return true;
+    }
+    let basename = std::path::Path::new(display_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    !basename.is_empty() && basename != display_path && pattern.matches(basename)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn guess_content(bytes: &[u8]) -> ProbableFileKind {
-        super::guess_content(bytes, &FileArgument::Stdin, &[])
+        super::guess_content(bytes, "", &[])
     }
 
     #[test]
@@ -433,5 +454,55 @@ mod tests {
             0xfc, 0x0c, 0x56, 0x1e, 0x93, 0xcb, 0x71, 0x92, 0x82, 0x60, 0x16, 0x37,
         ];
         assert_eq!(guess_content(&bytes), ProbableFileKind::Binary);
+    }
+
+    fn pattern(s: &str) -> glob::Pattern {
+        glob::Pattern::new(s).expect("test pattern should parse")
+    }
+
+    #[test]
+    fn override_matches_root_filename() {
+        assert!(matches_override(&pattern("*.toml"), "rust-toolchain.toml"));
+    }
+
+    #[test]
+    fn override_matches_filename_at_depth() {
+        // The reported #967 case: a file living deeper than the diff root.
+        // `*.toml` should still treat it as binary.
+        assert!(matches_override(
+            &pattern("*.toml"),
+            "crates/foo/rust-toolchain.toml",
+        ));
+    }
+
+    #[test]
+    fn override_matches_path_shaped_pattern() {
+        // Patterns containing a slash retain their path-anchored meaning.
+        assert!(matches_override(
+            &pattern("build/*.lock"),
+            "build/Cargo.lock",
+        ));
+    }
+
+    #[test]
+    fn override_does_not_match_path_shaped_pattern_outside_anchor() {
+        // `build/*.lock` should NOT match a `Cargo.lock` outside `build/`.
+        assert!(!matches_override(
+            &pattern("build/*.lock"),
+            "crates/build/Cargo.lock",
+        ));
+    }
+
+    #[test]
+    fn override_does_not_match_non_matching_extension() {
+        // Make sure the basename fallback doesn't fire for unrelated names.
+        assert!(!matches_override(&pattern("*.gz"), "src/main.rs"));
+    }
+
+    #[test]
+    fn override_handles_empty_display_path() {
+        // Stdin / empty display path: the override loop is short-circuited
+        // by the caller, but the helper itself must not crash on it.
+        assert!(!matches_override(&pattern("*.toml"), ""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,8 +417,8 @@ fn diff_file(
     let (lhs_bytes, rhs_bytes) = read_files_or_die(lhs_path, rhs_path, missing_as_empty);
 
     let (mut lhs_src, mut rhs_src) = match (
-        guess_content(&lhs_bytes, lhs_path, binary_overrides),
-        guess_content(&rhs_bytes, rhs_path, binary_overrides),
+        guess_content(&lhs_bytes, display_path, binary_overrides),
+        guess_content(&rhs_bytes, display_path, binary_overrides),
         check_diff_attr(Path::new(display_path)),
     ) {
         (ProbableFileKind::Binary, _, _)
@@ -506,7 +506,7 @@ fn diff_conflicts_file(
     binary_overrides: &[glob::Pattern],
 ) -> DiffResult {
     let bytes = read_file_or_die(path);
-    let mut src = match guess_content(&bytes, path, binary_overrides) {
+    let mut src = match guess_content(&bytes, display_path, binary_overrides) {
         ProbableFileKind::Text(src) => src,
         ProbableFileKind::Binary => {
             print_error(


### PR DESCRIPTION
## Summary

Closes #967.

`guess_content` matches `DFT_OVERRIDE_BINARY` glob patterns against the `FileArgument` it receives. When difftastic is invoked as `GIT_EXTERNAL_DIFF` (the canonical setup, including @osa1's `git diff` repro in the issue), git passes the **temp file paths** as the lhs/rhs arguments and only puts the logical filename in `display_path`. From [`src/options.rs:918-928`](https://github.com/Wilfred/difftastic/blob/master/src/options.rs#L918-L928):

```rust
[display_path, lhs_tmp_file, _hash, lhs_mode, rhs_tmp_file, _hash, rhs_mode] => {
    (
        display_path.to_string_lossy().to_string(),  // logical filename
        FileArgument::from_path_argument(lhs_tmp_file),  // /tmp/abc123
        FileArgument::from_path_argument(rhs_tmp_file),  // /tmp/def456
        ...
    )
}
```

So `*.toml` was being matched against something like `/tmp/abc123` and silently never fired for any user with difft set up through git's external-diff hook — including the deleted-file case in the report, where the rhs is `/dev/null`.

## Fix

Match against `display_path` instead of the `FileArgument`'s temp path. The `display_path: &str` is already plumbed through both callers (`diff_file` and `diff_conflicts_file`) and is the same string `check_diff_attr` already operates on, so all three arms of the existing match expression now agree on what "this file's name" means.

While here, also try the basename when an unanchored pattern fails to match the full path. The `glob` crate treats `*` as not crossing `/`, so before this change `*.toml` wouldn't match `crates/foo/file.toml` even with `display_path` wired up correctly. That's the **"issue with `/` in glob patterns"** behaviour you flagged when you reopened the issue:

```rust
fn matches_override(pattern: &glob::Pattern, display_path: &str) -> bool {
    if pattern.matches(display_path) {
        return true;
    }
    let basename = std::path::Path::new(display_path)
        .file_name()
        .and_then(|s| s.to_str())
        .unwrap_or("");
    !basename.is_empty() && basename != display_path && pattern.matches(basename)
}
```

Path-shaped patterns containing `/` keep their anchored semantics — the basename fallback only fires when the full match has already failed, and we guard against treating a path with no parent as "different from its basename" so the fallback is a no-op for root-level files (avoids redundantly running `pattern.matches` twice).

## Test plan

Six new unit tests in `files.rs::tests`:

| case | covers |
|---|---|
| `override_matches_root_filename` | `*.toml` vs `rust-toolchain.toml` |
| `override_matches_filename_at_depth` | the #967 case: `*.toml` vs `crates/foo/rust-toolchain.toml` |
| `override_matches_path_shaped_pattern` | `build/*.lock` vs `build/Cargo.lock` (anchored hit) |
| `override_does_not_match_path_shaped_pattern_outside_anchor` | `build/*.lock` does NOT match `crates/build/Cargo.lock` (no false positive) |
| `override_does_not_match_non_matching_extension` | `*.gz` vs `src/main.rs` (basename fallback doesn't false-positive) |
| `override_handles_empty_display_path` | helper doesn't crash on `""` |

I extracted `matches_override` into a standalone Cargo workspace and ran the suite there — 6/6 passing. I wasn't able to run `cargo test` against the full difftastic tree on this Windows box because the vendored-parser symlinks need either developer mode or admin to materialise; the helper's logic is fully covered by the standalone run, and the two `main.rs` callsite changes are mechanical (both already had `display_path: &str` in scope).

## Notes / open questions

- **Pre-existing `FileArgument` parameter on `guess_content` removed** — it was only used for the override match; the rest of the function reads `bytes`. If you'd rather keep the parameter for symmetry with other call shapes I can leave it in as `_path: &FileArgument`, but dropping it seemed cleaner.
- **Test wrapper updated** — the `#[cfg(test)] fn guess_content` shim in `files.rs` now passes `""` instead of `&FileArgument::Stdin`. No registered overrides in those tests so the loop short-circuits identically.
- The basename-fallback semantics aren't quite full gitignore (which would also support `**/*.toml` for "any depth" and treat `src/foo` as anchored only at the root), but they handle the dominant `*.<ext>` and `bare-filename` shapes that `DFT_OVERRIDE_BINARY` is documented with. Happy to take it further toward full `globset`/`ignore`-crate semantics if you'd prefer that direction in a follow-up.

Credit to @osa1 for the report and the patient back-and-forth on repro details.