### PR TITLE
Show unchanged lines that fall inside an inline hunk

### DIFF
--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -1,5 +1,7 @@
 //! Inline, or "unified" diff display.
 
+use line_numbers::LineNumber;
+
 use crate::constants::Side;
 use crate::display::context::{
     calculate_after_context, calculate_before_context, opposite_positions,
@@ -10,6 +12,50 @@ use crate::lines::{format_line_num, split_on_newlines, MaxLine};
 use crate::options::DisplayOptions;
 use crate::parse::syntax::MatchedPos;
 use crate::summary::FileFormat;
+
+/// Expand `hunk.lines` to include any unchanged lines that fall between
+/// changed lines on the same side. Without this, inline display drops
+/// in-hunk context, which can hide section headings and similar
+/// structural lines (issue #978).
+fn fill_in_hunk_gaps(
+    lines: &[(Option<LineNumber>, Option<LineNumber>)],
+) -> Vec<(Option<LineNumber>, Option<LineNumber>)> {
+    let mut filled = Vec::with_capacity(lines.len());
+
+    let mut prev_lhs: Option<LineNumber> = None;
+    let mut prev_rhs: Option<LineNumber> = None;
+
+    for (lhs_line, rhs_line) in lines {
+        let lhs_gap: Vec<LineNumber> = match (prev_lhs, *lhs_line) {
+            (Some(prev), Some(curr)) if prev.0 + 1 < curr.0 => {
+                (prev.0 + 1..curr.0).map(LineNumber::from).collect()
+            }
+            _ => vec![],
+        };
+        let rhs_gap: Vec<LineNumber> = match (prev_rhs, *rhs_line) {
+            (Some(prev), Some(curr)) if prev.0 + 1 < curr.0 => {
+                (prev.0 + 1..curr.0).map(LineNumber::from).collect()
+            }
+            _ => vec![],
+        };
+
+        let pair_count = lhs_gap.len().max(rhs_gap.len());
+        for i in 0..pair_count {
+            filled.push((lhs_gap.get(i).copied(), rhs_gap.get(i).copied()));
+        }
+
+        filled.push((*lhs_line, *rhs_line));
+
+        if lhs_line.is_some() {
+            prev_lhs = *lhs_line;
+        }
+        if rhs_line.is_some() {
+            prev_rhs = *rhs_line;
+        }
+    }
+
+    filled
+}
 
 pub(crate) fn print(
     lhs_src: &str,
@@ -77,7 +123,7 @@ pub(crate) fn print(
             )
         );
 
-        let hunk_lines = hunk.lines.clone();
+        let hunk_lines = fill_in_hunk_gaps(&hunk.lines);
 
         let before_lines = calculate_before_context(
             &hunk_lines,
@@ -112,11 +158,12 @@ pub(crate) fn print(
 
         for (lhs_line, _) in &hunk_lines {
             if let Some(lhs_line) = lhs_line {
+                let is_novel = hunk.novel_lhs.contains(lhs_line);
                 print!(
                     "{}   {}",
                     apply_line_number_color(
                         &format_line_num(*lhs_line),
-                        true,
+                        is_novel,
                         Side::Left,
                         display_options,
                     ),
@@ -126,11 +173,12 @@ pub(crate) fn print(
         }
         for (_, rhs_line) in &hunk_lines {
             if let Some(rhs_line) = rhs_line {
+                let is_novel = hunk.novel_rhs.contains(rhs_line);
                 print!(
                     "   {}{}",
                     apply_line_number_color(
                         &format_line_num(*rhs_line),
-                        true,
+                        is_novel,
                         Side::Right,
                         display_options,
                     ),
@@ -154,5 +202,94 @@ pub(crate) fn print(
             }
         }
         println!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ln(n: u32) -> LineNumber {
+        n.into()
+    }
+
+    #[test]
+    fn fill_in_hunk_gaps_empty() {
+        assert!(fill_in_hunk_gaps(&[]).is_empty());
+    }
+
+    #[test]
+    fn fill_in_hunk_gaps_no_gap() {
+        let input = vec![(Some(ln(0)), Some(ln(0))), (Some(ln(1)), Some(ln(1)))];
+        assert_eq!(fill_in_hunk_gaps(&input), input);
+    }
+
+    #[test]
+    fn fill_in_hunk_gaps_lhs_only_change_then_unchanged() {
+        // LHS has a removed line at 0, unchanged lines at 1, 2 (both
+        // sides), then an RHS-only added line at index 1. Filling the
+        // gap inside the hunk should insert the unchanged lines that
+        // sit between novel changes.
+        let input = vec![(Some(ln(0)), None), (Some(ln(3)), Some(ln(3)))];
+        let filled = fill_in_hunk_gaps(&input);
+        assert_eq!(
+            filled,
+            vec![
+                (Some(ln(0)), None),
+                (Some(ln(1)), None),
+                (Some(ln(2)), None),
+                (Some(ln(3)), Some(ln(3))),
+            ]
+        );
+    }
+
+    #[test]
+    fn fill_in_hunk_gaps_section_header_between_changes() {
+        // Mimics issue #978: a hunk that contains LHS-only and RHS-only
+        // changes separated by lines that are unchanged on both sides.
+        // The unchanged lines are not in the input. After filling, each
+        // side's gap is rebuilt so the inline display can print them as
+        // in-hunk context.
+        let input = vec![
+            (Some(ln(4)), None),
+            (None, Some(ln(4))),
+            (Some(ln(7)), None),
+            (None, Some(ln(7))),
+        ];
+        let filled = fill_in_hunk_gaps(&input);
+        assert_eq!(
+            filled,
+            vec![
+                (Some(ln(4)), None),
+                (None, Some(ln(4))),
+                (Some(ln(5)), None),
+                (Some(ln(6)), None),
+                (Some(ln(7)), None),
+                (None, Some(ln(5))),
+                (None, Some(ln(6))),
+                (None, Some(ln(7))),
+            ]
+        );
+    }
+
+    #[test]
+    fn fill_in_hunk_gaps_unequal_gap_lengths() {
+        // The RHS gap (lines 1..6 = 5 lines) is longer than the LHS gap
+        // (lines 1..3 = 2 lines). The filler pairs them up and pads the
+        // shorter side with None.
+        let input = vec![(Some(ln(0)), Some(ln(0))), (Some(ln(3)), Some(ln(6)))];
+        let filled = fill_in_hunk_gaps(&input);
+        assert_eq!(
+            filled,
+            vec![
+                (Some(ln(0)), Some(ln(0))),
+                (Some(ln(1)), Some(ln(1))),
+                (Some(ln(2)), Some(ln(2))),
+                (None, Some(ln(3))),
+                (None, Some(ln(4))),
+                (None, Some(ln(5))),
+                (Some(ln(3)), Some(ln(6))),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #978.

## Bug

When two novel lines in a hunk are close enough that the merge step in `display::hunks::merge_adjacent` combines them into one hunk, the unchanged lines between them are silently dropped from inline (`--display=inline`) output. Side-by-side and JSON output don't have this problem because both use `matched_lines_indexes_for_hunk` to walk the full hunk range, so they already include the in-between unchanged lines. Inline was iterating `hunk.lines` directly, and that field only contains positions with novel content.

In the report this surfaces as a missing section heading on a `.gitconfig`:

```
$ difft before.gitconfig after.gitconfig --display=inline
```

The line `[url "ssh://git@github.com"]` between two changed `pushInsteadOf =` lines does not appear.

## Repro

`before.gitconfig`:

```
[uploadpack]
    allowFilter = true

[url "ssh://aur@aur.archlinux.org"]
    pushInsteadOf = "https://aur.archlinux.org"

[url "ssh://git@github.com"]
    pushInsteadOf = "https://github.com"

[versionsort]
    # prereleaseSuffix is deprecated in favour of suffix
```

`after.gitconfig` (same, but both `pushInsteadOf` lines are commented out):

```
[uploadpack]
    allowFilter = true

[url "ssh://aur@aur.archlinux.org"]
    ; pushInsteadOf = "https://aur.archlinux.org"

[url "ssh://git@github.com"]
    ; pushInsteadOf = "https://github.com"

[versionsort]
    # prereleaseSuffix is deprecated in favour of suffix
```

### Before this PR

```
/tmp/after3.gitconfig --- Text
1    [uploadpack]
2        allowFilter = true
3    
4    [url "ssh://aur@aur.archlinux.org"]
5        pushInsteadOf = "https://aur.archlinux.org"
8        pushInsteadOf = "https://github.com"
   5     ; pushInsteadOf = "https://aur.archlinux.org"
   8     ; pushInsteadOf = "https://github.com"
   9 
   10 [versionsort]
   11     # prereleaseSuffix is deprecated in favour of suffix
```

Lines 6 (blank) and 7 (`[url "ssh://git@github.com"]`) are missing on both sides.

### After this PR

```
/tmp/after3.gitconfig --- Text
1    [uploadpack]
2        allowFilter = true
3    
4    [url "ssh://aur@aur.archlinux.org"]
5        pushInsteadOf = "https://aur.archlinux.org"
6    
7    [url "ssh://git@github.com"]
8        pushInsteadOf = "https://github.com"
   5     ; pushInsteadOf = "https://aur.archlinux.org"
   6 
   7 [url "ssh://git@github.com"]
   8     ; pushInsteadOf = "https://github.com"
   9 
   10 [versionsort]
   11     # prereleaseSuffix is deprecated in favour of suffix
```

## Fix

Add a small `fill_in_hunk_gaps` helper in `src/display/inline.rs` that walks `hunk.lines` and emits the intervening line numbers for each side, then update the LHS and RHS print loops to consult `hunk.novel_lhs` / `hunk.novel_rhs` so the new gap entries render with dimmed (context) line numbers instead of bold red / green ones.

I considered switching inline to use `all_matched_lines_filled` + `matched_lines_indexes_for_hunk` the same way side-by-side does, but that would also require restructuring how the before / after context loops are integrated. This narrower change keeps the existing structure and only fixes the dropped-context-inside-hunk case.

## Testing

- Added four unit tests for `fill_in_hunk_gaps` covering the empty input, no-gap, LHS-only-changes-with-an-unchanged-tail, and unequal-side-gaps shapes.
- `cargo test --release` (148 tests) passes.
- Manually verified against the `.gitconfig` repro above and against syntactic (Rust) inputs to confirm the multi-hunk path still splits correctly when changes are far apart.