### PR TITLE
Update tikv-jemallocator from 0.6 to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ tree-sitter-vhdl = "1.4.0"
 
 
 [target.'cfg(not(any(windows, target_os = "illumos", target_os = "freebsd")))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"


### PR DESCRIPTION
See https://github.com/tikv/jemallocator/blob/0.7.0/CHANGELOG.md and https://github.com/jemalloc/jemalloc/blob/5.3.1/ChangeLog.

I don’t know of an urgent reason for this update, although there are quite a few bugfixes in the changelog for jemalloc 5.3.1. I’m working on updating the `rust-tikv-jemallocator` package in Fedora without introducing a `rust-tikv-jemallocator0.6` compat package, and this PR is part of offering the necessary changes upstream.