### PR TITLE
Add short arg -c for context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Improved diffing performance, particularly when diffing directories.
 
 Removed support for SCSS (upstream parser is no longer maintained).
 
+### Command Line Interface
+
+`--context` can now be set with the short flag `-c`.
+
 ## 0.69 (released 30th April 2026)
 
 ## Diffing

--- a/src/options.rs
+++ b/src/options.rs
@@ -175,6 +175,7 @@ fn app() -> clap::Command {
         .arg(
             Arg::new("context")
                 .long("context")
+                .short('c')
                                 .value_name("LINES")
                 .action(ArgAction::Set)
                 .long_help("The number of contextual lines to show around changed lines.")


### PR DESCRIPTION
This mirrors `diff` and helps with typing.