### PR TITLE
Add --show-function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Improved diffing performance, particularly when diffing directories.
 
 Removed support for SCSS (upstream parser is no longer maintained).
 
+### Command Line Interface
+
+Added `-p, --show-function` (`-p`), which displays the definition line of the
+function enclosing each change, similar to `git diff --function-context`. Can
+be disabled if set by an environment variable with `-p, --no-show-function`. It
+accepts an optional mode (currently only `default`, e.g.
+`--show-function=default`) to allow for more display modes in future. See issue
+#666.
+
 ## 0.69 (released 30th April 2026)
 
 ## Diffing

--- a/manual/src/contributing.md
+++ b/manual/src/contributing.md
@@ -58,7 +58,8 @@ not support binary crates today](https://github.com/rust-lang/docs.rs/issues/238
 $ cargo test
 ```
 
-There are also several files in `sample_files/` that you can use.
+There are also several files in `sample_files/` that you can use. Use
+`./sample_files/compare_all.sh` to run across all samples and compare them.
 
 The best way to test difftastic is to look at history from a real
 project. Set `GIT_EXTERNAL_DIFF` to point to your current build.

--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -241,6 +241,30 @@ sample_files/scala_1.scala sample_files/scala_2.scala
 sample_files/scheme_1.scm sample_files/scheme_2.scm
 53c43d0dd0aea0f3e49385cc6d520963  -
 
+sample_files/show_function_c_1.c sample_files/show_function_c_2.c
+585b22d3c30f1b61f418c76d40e89bb0  -
+
+sample_files/show_function_delete_1.rs sample_files/show_function_delete_2.rs
+255702f8aa4de69e9bb957fcce8075d5  -
+
+sample_files/show_function_nested_oneline_1.rs sample_files/show_function_nested_oneline_2.rs
+4dd191cb37e5f39fd68c0bd5b6c328bc  -
+
+sample_files/show_function_new_inner_1.rs sample_files/show_function_new_inner_2.rs
+f323149ed6f9c723b204eb2c4e43a2a6  -
+
+sample_files/show_function_php_1.php sample_files/show_function_php_2.php
+382c74efc754f56d920219e1f34f4659  -
+
+sample_files/show_function_python_1.py sample_files/show_function_python_2.py
+a0d9bafad62e3eed083a2d09db459ab9  -
+
+sample_files/show_function_rename_1.rs sample_files/show_function_rename_2.rs
+52d5445f67620344984cdba60a27e0c6  -
+
+sample_files/show_function_rust_1.rs sample_files/show_function_rust_2.rs
+2e352b86a763770581ede4c3d07c81bc  -
+
 sample_files/simple_1.js sample_files/simple_2.js
 f73ae56c0467bac101bb5f7a435f89f3  -
 

--- a/sample_files/show_function_c_1.c
+++ b/sample_files/show_function_c_1.c
@@ -1,0 +1,13 @@
+int top_level_value = 1;
+
+
+
+
+int enclosing_function(int input) {
+    int a = input + 1;
+    int b = a + 2;
+    int c = b + 3;
+    int d = c + 4;
+    int e = d + 5;
+    return e;
+}

--- a/sample_files/show_function_c_2.c
+++ b/sample_files/show_function_c_2.c
@@ -1,0 +1,13 @@
+int top_level_value = 1;
+
+
+
+
+int enclosing_function(int input) {
+    int a = input + 1;
+    int b = a + 2;
+    int c = b + 3;
+    int d = c + 4;
+    int e = d + 500;
+    return e;
+}

--- a/sample_files/show_function_c_toplevel.c
+++ b/sample_files/show_function_c_toplevel.c
@@ -1,0 +1,13 @@
+int top_level_value = 2;
+
+
+
+
+int enclosing_function(int input) {
+    int a = input + 1;
+    int b = a + 2;
+    int c = b + 3;
+    int d = c + 4;
+    int e = d + 5;
+    return e;
+}

--- a/sample_files/show_function_delete_1.rs
+++ b/sample_files/show_function_delete_1.rs
@@ -1,0 +1,9 @@
+fn top_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    fn deleted_inner() {
+        99
+    }
+}

--- a/sample_files/show_function_delete_2.rs
+++ b/sample_files/show_function_delete_2.rs
@@ -1,0 +1,6 @@
+fn top_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+}

--- a/sample_files/show_function_nested_oneline_1.rs
+++ b/sample_files/show_function_nested_oneline_1.rs
@@ -1,0 +1,6 @@
+fn outer_oneline() { fn inner_oneline() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+} }

--- a/sample_files/show_function_nested_oneline_2.rs
+++ b/sample_files/show_function_nested_oneline_2.rs
@@ -1,0 +1,6 @@
+fn outer_oneline() { fn inner_oneline() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 400;
+} }

--- a/sample_files/show_function_new_inner_1.rs
+++ b/sample_files/show_function_new_inner_1.rs
@@ -1,0 +1,8 @@
+fn outer_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let e = 5;
+    let result = a + b;
+}

--- a/sample_files/show_function_new_inner_2.rs
+++ b/sample_files/show_function_new_inner_2.rs
@@ -1,0 +1,11 @@
+fn outer_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let e = 5;
+    fn inner_helper() -> i32 {
+        42
+    }
+    let result = a + b;
+}

--- a/sample_files/show_function_php_1.php
+++ b/sample_files/show_function_php_1.php
@@ -1,0 +1,14 @@
+<?php
+$top_level_value = 1;
+
+
+
+
+function enclosing_function($input) {
+    $a = $input + 1;
+    $b = $a + 2;
+    $c = $b + 3;
+    $d = $c + 4;
+    $e = $d + 5;
+    return $e;
+}

--- a/sample_files/show_function_php_2.php
+++ b/sample_files/show_function_php_2.php
@@ -1,0 +1,14 @@
+<?php
+$top_level_value = 1;
+
+
+
+
+function enclosing_function($input) {
+    $a = $input + 1;
+    $b = $a + 2;
+    $c = $b + 3;
+    $d = $c + 4;
+    $e = $d + 500;
+    return $e;
+}

--- a/sample_files/show_function_php_toplevel.php
+++ b/sample_files/show_function_php_toplevel.php
@@ -1,0 +1,14 @@
+<?php
+$top_level_value = 2;
+
+
+
+
+function enclosing_function($input) {
+    $a = $input + 1;
+    $b = $a + 2;
+    $c = $b + 3;
+    $d = $c + 4;
+    $e = $d + 5;
+    return $e;
+}

--- a/sample_files/show_function_python_1.py
+++ b/sample_files/show_function_python_1.py
@@ -1,0 +1,12 @@
+TOP_LEVEL_VALUE = 1
+
+
+
+
+def enclosing_function(input):
+    a = input + 1
+    b = a + 2
+    c = b + 3
+    d = c + 4
+    e = d + 5
+    return e

--- a/sample_files/show_function_python_2.py
+++ b/sample_files/show_function_python_2.py
@@ -1,0 +1,12 @@
+TOP_LEVEL_VALUE = 1
+
+
+
+
+def enclosing_function(input):
+    a = input + 1
+    b = a + 2
+    c = b + 3
+    d = c + 4
+    e = d + 500
+    return e

--- a/sample_files/show_function_python_toplevel.py
+++ b/sample_files/show_function_python_toplevel.py
@@ -1,0 +1,12 @@
+TOP_LEVEL_VALUE = 2
+
+
+
+
+def enclosing_function(input):
+    a = input + 1
+    b = a + 2
+    c = b + 3
+    d = c + 4
+    e = d + 5
+    return e

--- a/sample_files/show_function_rename_1.rs
+++ b/sample_files/show_function_rename_1.rs
@@ -1,0 +1,7 @@
+fn top_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    fn original_name() {}
+}

--- a/sample_files/show_function_rename_2.rs
+++ b/sample_files/show_function_rename_2.rs
@@ -1,0 +1,7 @@
+fn top_function() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    fn renamed_name() {}
+}

--- a/sample_files/show_function_rust_1.rs
+++ b/sample_files/show_function_rust_1.rs
@@ -1,0 +1,13 @@
+const TOP_LEVEL_VALUE: i32 = 1;
+
+
+
+
+fn enclosing_function(input: i32) -> i32 {
+    let a = input + 1;
+    let b = a + 2;
+    let c = b + 3;
+    let d = c + 4;
+    let e = d + 5;
+    e
+}

--- a/sample_files/show_function_rust_2.rs
+++ b/sample_files/show_function_rust_2.rs
@@ -1,0 +1,13 @@
+const TOP_LEVEL_VALUE: i32 = 1;
+
+
+
+
+fn enclosing_function(input: i32) -> i32 {
+    let a = input + 1;
+    let b = a + 2;
+    let c = b + 3;
+    let d = c + 4;
+    let e = d + 500;
+    e
+}

--- a/sample_files/show_function_rust_toplevel.rs
+++ b/sample_files/show_function_rust_toplevel.rs
@@ -1,0 +1,13 @@
+const TOP_LEVEL_VALUE: i32 = 2;
+
+
+
+
+fn enclosing_function(input: i32) -> i32 {
+    let a = input + 1;
+    let b = a + 2;
+    let c = b + 3;
+    let d = c + 4;
+    let e = d + 5;
+    e
+}

--- a/src/display/hunks.rs
+++ b/src/display/hunks.rs
@@ -681,6 +681,52 @@ pub(crate) fn matched_lines_indexes_for_hunk(
     (start_i, end_i)
 }
 
+/// The line that defines the function enclosing `line`, i.e. the first line of
+/// that function's definition, if any.
+///
+/// Only considers functions preceding `line` so the result is always a
+/// contextual line rather than part of the change itself.
+///
+/// When a change adds a new inner function, e.g. `line` is part of that inner
+/// function's definition, we skip it and return the enclosing function instead.
+/// To find the innermost nested function we compare the `start` line numbers
+/// because a nested function always begins on a later line than the function
+/// that encloses it.
+pub(crate) fn enclosing_function_def(
+    line: LineNumber,
+    spans: &[(LineNumber, LineNumber)],
+) -> Option<LineNumber> {
+    spans
+        .iter()
+        .filter(|(start, end)| *start < line && line <= *end)
+        .max_by_key(|(start, _)| start.0)
+        .map(|(start, _)| *start)
+}
+
+/// For the change described by `hunk`, find the definition line of the
+/// function enclosing it on each side. Used by `--show-function`. If the change
+/// isn't inside any known functions returns `(None, None)`.
+pub(crate) fn enclosing_function_line(
+    hunk: &Hunk,
+    lhs_fn_spans: &[(LineNumber, LineNumber)],
+    rhs_fn_spans: &[(LineNumber, LineNumber)],
+) -> (Option<LineNumber>, Option<LineNumber>) {
+    let lhs_def = hunk
+        .novel_lhs
+        .iter()
+        .min()
+        .copied()
+        .and_then(|line| enclosing_function_def(line, lhs_fn_spans));
+    let rhs_def = hunk
+        .novel_rhs
+        .iter()
+        .min()
+        .copied()
+        .and_then(|line| enclosing_function_def(line, rhs_fn_spans));
+
+    (lhs_def, rhs_def)
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter::FromIterator;
@@ -691,6 +737,62 @@ mod tests {
     use super::*;
     use crate::hash::DftHashMap;
     use crate::syntax::{MatchKind, TokenKind};
+
+    #[test]
+    fn test_enclosing_function_def_body_change() {
+        // A change inside a function body returns the function's
+        // definition line.
+        let spans = [(LineNumber(2), LineNumber(8))];
+        assert_eq!(
+            enclosing_function_def(LineNumber(5), &spans),
+            Some(LineNumber(2))
+        );
+    }
+
+    #[test]
+    fn test_enclosing_function_def_top_level() {
+        // A change outside any function has no enclosing definition.
+        let spans = [(LineNumber(2), LineNumber(8))];
+        assert_eq!(enclosing_function_def(LineNumber(0), &spans), None);
+    }
+
+    #[test]
+    fn test_enclosing_function_def_nested_returns_innermost() {
+        // outer spans 1..=10, inner spans 4..=7. A change at line 5 is
+        // inside the inner function.
+        let spans = [
+            (LineNumber(1), LineNumber(10)),
+            (LineNumber(4), LineNumber(7)),
+        ];
+        assert_eq!(
+            enclosing_function_def(LineNumber(5), &spans),
+            Some(LineNumber(4))
+        );
+    }
+
+    #[test]
+    fn test_enclosing_function_def_new_inner_returns_outer() {
+        // A newly-added inner function: the change starts on the inner
+        // function's own definition line (4). We skip it (its
+        // definition *is* the change) and return the enclosing outer
+        // function (line 1).
+        let spans = [
+            (LineNumber(1), LineNumber(10)),
+            (LineNumber(4), LineNumber(7)),
+        ];
+        assert_eq!(
+            enclosing_function_def(LineNumber(4), &spans),
+            Some(LineNumber(1))
+        );
+    }
+
+    #[test]
+    fn test_enclosing_function_def_change_on_top_level_def() {
+        // A change on a top-level function's own definition line
+        // (e.g. renaming or deleting it) has no enclosing function.
+        let spans = [(LineNumber(2), LineNumber(8))];
+        assert_eq!(enclosing_function_def(LineNumber(2), &spans), None);
+    }
 
     #[test]
     fn test_sorted_novel_positions_simple() {

--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -1,10 +1,12 @@
 //! Inline, or "unified" diff display.
 
+use line_numbers::LineNumber;
+
 use crate::constants::Side;
 use crate::display::context::{
     calculate_after_context, calculate_before_context, opposite_positions,
 };
-use crate::display::hunks::Hunk;
+use crate::display::hunks::{enclosing_function_def, Hunk};
 use crate::display::style::{self, apply_colors, apply_line_number_color};
 use crate::lines::{format_line_num, format_line_num_padded, split_on_newlines, MaxLine};
 use crate::options::DisplayOptions;
@@ -21,6 +23,7 @@ pub(crate) fn print(
     display_path: &str,
     extra_info: &Option<String>,
     file_format: &FileFormat,
+    lhs_fn_spans: &[(LineNumber, LineNumber)],
 ) {
     let (lhs_colored_lines, rhs_colored_lines) = if display_options.use_color {
         (
@@ -83,12 +86,41 @@ pub(crate) fn print(
 
         let hunk_lines = hunk.lines.clone();
 
-        let before_lines = calculate_before_context(
+        let mut before_lines = calculate_before_context(
             &hunk_lines,
             &opposite_to_lhs,
             &opposite_to_rhs,
             display_options.num_context_lines as usize,
         );
+
+        // With --show-functions, add the definition line of the enclosing
+        // function as extra before-context if it is not already displayed.
+        if display_options.show_function.is_some() {
+            // Anchor on the LHS line at/closest-above the change. For a
+            // pure addition there are no novel LHS lines, so fall back
+            // to the last LHS context line (immediately above the
+            // insertion point, still inside the enclosing function).
+            let anchor_lhs = hunk
+                .novel_lhs
+                .iter()
+                .min()
+                .copied()
+                .or_else(|| before_lines.iter().rev().find_map(|(lhs, _)| *lhs))
+                .or_else(|| hunk_lines.iter().find_map(|(lhs, _)| *lhs));
+
+            if let Some(def) =
+                anchor_lhs.and_then(|line| enclosing_function_def(line, lhs_fn_spans))
+            {
+                let first_lhs = before_lines
+                    .iter()
+                    .find_map(|(lhs, _)| *lhs)
+                    .or_else(|| hunk_lines.iter().find_map(|(lhs, _)| *lhs));
+                let above = first_lhs.is_none_or(|first| def < first);
+                if above {
+                    before_lines.insert(0, (Some(def), None));
+                }
+            }
+        }
         let after_lines = calculate_after_context(
             &[&before_lines[..], &hunk_lines[..]].concat(),
             &opposite_to_lhs,

--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -7,7 +7,7 @@ use owo_colors::{OwoColorize, Style};
 
 use crate::constants::Side;
 use crate::display::context::all_matched_lines_filled;
-use crate::display::hunks::{matched_lines_indexes_for_hunk, Hunk};
+use crate::display::hunks::{enclosing_function_line, matched_lines_indexes_for_hunk, Hunk};
 use crate::display::style::{
     self, apply_colors, apply_line_number_color, color_positions, novel_style, replace_tabs,
     split_and_apply, width_respecting_tabs, BackgroundColor,
@@ -334,15 +334,32 @@ fn highlight_as_novel(
 
 /// Find the longest line in `lhs_src` and `rhs_src` that will be
 /// displayed. Return the length of that line for both LHS and RHS.
+///
+/// `lhs_fn_spans`/`rhs_fn_spans` are the function spans used by
+/// `--show-function`; they're empty when the feature is disabled. We
+/// account for the enclosing-function definition lines here so the
+/// column is wide enough and the signature doesn't wrap.
 fn visible_content_max_display_width(
     lhs_src: &str,
     rhs_src: &str,
     hunks: &[Hunk],
     num_context_lines: u32,
     tab_width: usize,
+    lhs_fn_spans: &[(LineNumber, LineNumber)],
+    rhs_fn_spans: &[(LineNumber, LineNumber)],
 ) -> (usize, usize) {
     let mut lhs_displayed_lines: DftHashSet<usize> = DftHashSet::default();
     let mut rhs_displayed_lines: DftHashSet<usize> = DftHashSet::default();
+
+    for hunk in hunks {
+        let (lhs_def, rhs_def) = enclosing_function_line(hunk, lhs_fn_spans, rhs_fn_spans);
+        if let Some(lhs_def) = lhs_def {
+            lhs_displayed_lines.insert(lhs_def.0 as usize);
+        }
+        if let Some(rhs_def) = rhs_def {
+            rhs_displayed_lines.insert(rhs_def.0 as usize);
+        }
+    }
 
     for hunk in hunks {
         let mut min_lhs_line: Option<LineNumber> = None;
@@ -422,6 +439,45 @@ fn visible_content_max_display_width(
     (lhs_content_max_width, rhs_content_max_width)
 }
 
+/// The extra context row to show for `--show-function`.
+fn function_context_row(
+    hunk: &Hunk,
+    lhs_fn_spans: &[(LineNumber, LineNumber)],
+    rhs_fn_spans: &[(LineNumber, LineNumber)],
+    matched_lines: &[(Option<LineNumber>, Option<LineNumber>)],
+    first_displayed: Option<&(Option<LineNumber>, Option<LineNumber>)>,
+) -> Option<(Option<LineNumber>, Option<LineNumber>)> {
+    let (lhs_def, rhs_def) = enclosing_function_line(hunk, lhs_fn_spans, rhs_fn_spans);
+    if lhs_def.is_none() && rhs_def.is_none() {
+        return None;
+    }
+
+    // Find the aligned row for the definition line so the definition shows
+    // correctly in both columns even when only one side has new content.
+    let def_row = *matched_lines.iter().find(|(lhs, rhs)| {
+        (lhs_def.is_some() && *lhs == lhs_def) || (rhs_def.is_some() && *rhs == rhs_def)
+    })?;
+
+    let (first_lhs, first_rhs) = match first_displayed {
+        Some((lhs, rhs)) => (*lhs, *rhs),
+        None => (None, None),
+    };
+
+    // Only show the definition if it sits strictly above the context
+    // already displayed (otherwise it's already visible).
+    let above = |def: Option<LineNumber>, first: Option<LineNumber>| match (def, first) {
+        (Some(def), Some(first)) => def < first,
+        (Some(_), None) => true,
+        _ => false,
+    };
+
+    if above(def_row.0, first_lhs) || above(def_row.1, first_rhs) {
+        Some(def_row)
+    } else {
+        None
+    }
+}
+
 pub(crate) fn print(
     hunks: &[Hunk],
     display_options: &DisplayOptions,
@@ -432,6 +488,8 @@ pub(crate) fn print(
     rhs_src: &str,
     lhs_mps: &[MatchedPos],
     rhs_mps: &[MatchedPos],
+    lhs_fn_spans: &[(LineNumber, LineNumber)],
+    rhs_fn_spans: &[(LineNumber, LineNumber)],
 ) {
     let (lhs_content_max_width, rhs_content_max_width) = visible_content_max_display_width(
         lhs_src,
@@ -439,6 +497,8 @@ pub(crate) fn print(
         hunks,
         display_options.num_context_lines,
         display_options.tab_width,
+        lhs_fn_spans,
+        rhs_fn_spans,
     );
 
     let (lhs_colored_lines, rhs_colored_lines) = if display_options.use_color {
@@ -629,7 +689,19 @@ pub(crate) fn print(
         let no_rhs_changes = hunk.novel_rhs.is_empty();
         let same_lines = aligned_lines.iter().all(|(l, r)| l == r);
 
-        for (lhs_line_num, rhs_line_num) in aligned_lines {
+        let fn_context_row = if display_options.show_function.is_some() {
+            function_context_row(
+                hunk,
+                lhs_fn_spans,
+                rhs_fn_spans,
+                &matched_lines,
+                aligned_lines.first(),
+            )
+        } else {
+            None
+        };
+
+        for (lhs_line_num, rhs_line_num) in fn_context_row.iter().chain(aligned_lines) {
             let lhs_line_novel = highlight_as_novel(
                 *lhs_line_num,
                 &lhs_lines,
@@ -912,6 +984,8 @@ mod tests {
             "bar",
             &lhs_mps,
             &rhs_mps,
+            &[],
+            &[],
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ use crate::lines::MaxLine;
 use crate::options::{DiffOptions, DisplayMode, DisplayOptions, FileArgument, Mode};
 use crate::parse::syntax::init_all_info;
 use crate::parse::tree_sitter_parser as tsp;
-use crate::summary::{DiffResult, FileContent, FileFormat};
+use crate::summary::{DiffResult, FileContent, FileFormat, FunctionSpans};
 use crate::syntax::init_next_prev;
 
 extern crate pretty_env_logger;
@@ -437,6 +437,8 @@ fn diff_file(
                 rhs_src: FileContent::Binary,
                 lhs_positions: vec![],
                 rhs_positions: vec![],
+                lhs_fn_spans: vec![],
+                rhs_fn_spans: vec![],
                 hunks: vec![],
                 has_byte_changes,
                 has_syntactic_changes: false,
@@ -595,6 +597,8 @@ fn check_only_text(
         rhs_src: FileContent::Text(rhs_src.into()),
         lhs_positions: vec![],
         rhs_positions: vec![],
+        lhs_fn_spans: vec![],
+        rhs_fn_spans: vec![],
         hunks: vec![],
         has_byte_changes,
         has_syntactic_changes: lhs_src != rhs_src,
@@ -636,11 +640,18 @@ fn diff_file_content(
             rhs_src: FileContent::Text("".into()),
             lhs_positions: vec![],
             rhs_positions: vec![],
+            lhs_fn_spans: vec![],
+            rhs_fn_spans: vec![],
             hunks: vec![],
             has_byte_changes: None,
             has_syntactic_changes: false,
         };
     }
+
+    // Populated below (only when --show-function is set and we have a
+    // tree-sitter parse) and carried into the DiffResult.
+    let mut lhs_fn_spans: FunctionSpans = Vec::new();
+    let mut rhs_fn_spans: FunctionSpans = Vec::new();
 
     let (file_format, lhs_positions, rhs_positions) = match lang_config {
         None => {
@@ -684,6 +695,8 @@ fn diff_file_content(
                                     rhs_src: FileContent::Text(rhs_src.to_owned()),
                                     lhs_positions: vec![],
                                     rhs_positions: vec![],
+                                    lhs_fn_spans: vec![],
+                                    rhs_fn_spans: vec![],
                                     hunks: vec![],
                                     has_byte_changes,
                                     has_syntactic_changes,
@@ -742,6 +755,11 @@ fn diff_file_content(
                                     let rhs_comments =
                                         tsp::comment_positions(&rhs_tree, rhs_src, lang_config);
                                     rhs_positions.extend(rhs_comments);
+                                }
+
+                                if display_options.show_function.is_some() {
+                                    lhs_fn_spans = tsp::function_spans(&lhs_tree);
+                                    rhs_fn_spans = tsp::function_spans(&rhs_tree);
                                 }
 
                                 (
@@ -832,6 +850,8 @@ fn diff_file_content(
         rhs_src: FileContent::Text(rhs_src.to_owned()),
         lhs_positions,
         rhs_positions,
+        lhs_fn_spans,
+        rhs_fn_spans,
         hunks,
         has_byte_changes,
         has_syntactic_changes,
@@ -953,6 +973,7 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
                         &summary.display_path,
                         &summary.extra_info,
                         &summary.file_format,
+                        &summary.lhs_fn_spans,
                     );
                 }
                 DisplayMode::SideBySide | DisplayMode::SideBySideShowBoth => {
@@ -966,6 +987,8 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
                         rhs_src,
                         &summary.lhs_positions,
                         &summary.rhs_positions,
+                        &summary.lhs_fn_spans,
+                        &summary.rhs_fn_spans,
                     );
                 }
                 DisplayMode::Json => unreachable!(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,6 +32,29 @@ pub(crate) enum ColorOutput {
     Never,
 }
 
+/// How `--show-function` should display the function enclosing each
+/// change. Currently only one mode exists; this is an enum so we can
+/// add more in future (e.g. showing the whole function, like `git diff
+/// -W`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShowFunction {
+    /// Show just the definition line of the enclosing function.
+    Default,
+}
+
+impl ShowFunction {
+    /// clap value parser for `--show-function` and `DFT_SHOW_FUNCTION`.
+    /// Accepts the mode name `default`, plus the truthy aliases
+    /// `1`/`true`/`yes`/`on` so that `DFT_SHOW_FUNCTION=1` enables the
+    /// feature. Any other value is rejected.
+    fn parse_arg(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "default" | "1" | "true" | "yes" | "on" => Ok(ShowFunction::Default),
+            other => Err(format!("invalid mode {other:?} (expected `default`)")),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct DisplayOptions {
     pub(crate) background_color: BackgroundColor,
@@ -43,6 +66,7 @@ pub(crate) struct DisplayOptions {
     pub(crate) num_context_lines: u32,
     pub(crate) syntax_highlight: bool,
     pub(crate) sort_paths: bool,
+    pub(crate) show_function: Option<ShowFunction>,
 }
 
 pub(crate) const DEFAULT_TERMINAL_WIDTH: usize = 80;
@@ -59,6 +83,7 @@ impl Default for DisplayOptions {
             num_context_lines: 3,
             syntax_highlight: true,
             sort_paths: false,
+            show_function: None,
         }
     }
 }
@@ -182,6 +207,27 @@ fn app() -> clap::Command {
                 .env("DFT_CONTEXT")
                 .value_parser(clap::value_parser!(u32))
                 .required(false),
+        )
+        .arg(
+            Arg::new("show-function")
+                .long("show-function")
+                .short('p')
+                .value_name("MODE")
+                .num_args(0..=1)
+                // Allow plain `-p` to work, otherwise `difft -p old new` would
+                // read `old` as the mode for `-p`.
+                .require_equals(true)
+                .default_missing_value("default")
+                .value_parser(ShowFunction::parse_arg)
+                .env("DFT_SHOW_FUNCTION")
+                .help("Show the definition line of the function enclosing each change, similar to `git diff --function-context`.\n\nAccepts an optional mode, e.g. --show-function=default; currently only `default` is supported, but more modes may be added in future. Setting DFT_SHOW_FUNCTION=1 (or =default) enables it too.")
+        )
+        .arg(
+            Arg::new("no-show-function")
+                .long("no-show-function")
+                .short('P')
+                .action(ArgAction::SetTrue)
+                .help("Disable --show-function. Takes precedence, so it can be used to override DFT_SHOW_FUNCTION.")
         )
         .arg(
             Arg::new("width")
@@ -848,6 +894,13 @@ pub(crate) fn parse_args() -> Mode {
         .get_one("context")
         .expect("Always present as we've given clap a default");
 
+    // Allow -P/--no-show-function to win over env variable DFT_SHOW_FUNCTION
+    let show_function = if matches.get_flag("no-show-function") {
+        None
+    } else {
+        matches.get_one::<ShowFunction>("show-function").copied()
+    };
+
     let print_unchanged = !matches.get_flag("skip-unchanged");
 
     let set_exit_code = matches.get_flag("exit-code");
@@ -956,6 +1009,7 @@ pub(crate) fn parse_args() -> Mode {
                 num_context_lines,
                 syntax_highlight,
                 sort_paths,
+                show_function,
             };
 
             let display_path = path.to_string_lossy().to_string();
@@ -1009,6 +1063,7 @@ pub(crate) fn parse_args() -> Mode {
         num_context_lines,
         syntax_highlight,
         sort_paths,
+        show_function,
     };
 
     Mode::Diff {

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{LazyLock, Mutex};
 
-use line_numbers::LinePositions;
+use line_numbers::{LineNumber, LinePositions};
 use streaming_iterator::StreamingIterator as _;
 use tree_sitter as ts;
 use typed_arena::Arena;
@@ -1465,6 +1465,69 @@ fn print_cursor(src: &str, cursor: &mut ts::TreeCursor, depth: usize) {
 
         if !cursor.goto_next_sibling() {
             break;
+        }
+    }
+}
+
+/// Is this tree-sitter node a function or method definition?
+///
+/// This is a best-effort list of node kinds covering the most common
+/// languages. Languages whose grammars use other node names simply
+/// won't show function context with `--show-function`.
+fn is_function_node_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        // Rust
+        "function_item"
+        // C, C++, Python, PHP, Bash, Julia, Lua, R, GLSL
+        | "function_definition"
+        // Go, JavaScript, Swift, Kotlin, Zig, Lua, OCaml
+        | "function_declaration"
+        // JavaScript, TypeScript
+        | "method_definition"
+        // Go, Java, C#, PHP, Kotlin
+        | "method_declaration"
+        // Java, C#
+        | "constructor_declaration"
+        // Ruby
+        | "method"
+        | "singleton_method"
+        // C#
+        | "local_function_statement"
+        // Perl
+        | "subroutine_declaration_statement"
+        // Haskell
+        | "function"
+    )
+}
+
+/// Return the `(start line, end line)` spans of every function and
+/// method definition in `tree`, including nested ones. Used by
+/// `--show-function` to display the function enclosing each change.
+pub(crate) fn function_spans(tree: &tree_sitter::Tree) -> Vec<(LineNumber, LineNumber)> {
+    let mut spans = vec![];
+    let mut cursor = tree.walk();
+
+    // Iterative pre-order traversal of the whole tree.
+    loop {
+        let node = cursor.node();
+        if is_function_node_kind(node.kind()) {
+            spans.push((
+                LineNumber(node.start_position().row as u32),
+                LineNumber(node.end_position().row as u32),
+            ));
+        }
+
+        if cursor.goto_first_child() {
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return spans;
+            }
         }
     }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -2,9 +2,16 @@
 
 use std::fmt::Display;
 
+use line_numbers::LineNumber;
+
 use crate::display::hunks::Hunk;
 use crate::parse::guess_language::{self, language_name};
 use crate::parse::syntax::MatchedPos;
+
+/// The `(start line, end line)` spans of the function and method
+/// definitions in a file. Used by `--show-function` to display the
+/// function enclosing each change.
+pub(crate) type FunctionSpans = Vec<(LineNumber, LineNumber)>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum FileContent {
@@ -45,6 +52,11 @@ pub(crate) struct DiffResult {
 
     pub(crate) lhs_positions: Vec<MatchedPos>,
     pub(crate) rhs_positions: Vec<MatchedPos>,
+
+    /// The function/method definition spans in each file. Empty unless
+    /// `--show-function` is enabled.
+    pub(crate) lhs_fn_spans: FunctionSpans,
+    pub(crate) rhs_fn_spans: FunctionSpans,
 
     /// If the two files do not have exactly the same bytes, the
     /// number of bytes in each file.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -291,3 +291,174 @@ fn git_unmerged_files() {
     let predicate_fn = predicate::str::contains("Unmerged path");
     cmd.assert().stdout(predicate_fn);
 }
+
+/// Assert that `--show-function` pulls in the definition of
+/// `function_name` as context, and that it is *not* shown without the
+/// flag (i.e. the definition is far enough away that only
+/// `--show-function` surfaces it).
+fn assert_function_context(old: &str, new: &str, function_name: &str) {
+    // Without --show-function, the distant definition is not displayed.
+    let mut cmd = get_base_command();
+    cmd.arg("--color=never").arg(old).arg(new);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(function_name).not());
+
+    // With --show-function, the enclosing definition is displayed.
+    let mut cmd = get_base_command();
+    cmd.arg("--color=never")
+        .arg("--show-function")
+        .arg(old)
+        .arg(new);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(function_name));
+}
+
+/// Assert that `--show-function` does not show `function_name`, e.g.
+/// because the change is not inside any function.
+fn assert_no_function_context(old: &str, new: &str, function_name: &str) {
+    let mut cmd = get_base_command();
+    cmd.arg("--color=never")
+        .arg("--show-function")
+        .arg(old)
+        .arg(new);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(function_name).not());
+}
+
+#[test]
+fn show_function_rust() {
+    assert_function_context(
+        "sample_files/show_function_rust_1.rs",
+        "sample_files/show_function_rust_2.rs",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_rust_top_level() {
+    assert_no_function_context(
+        "sample_files/show_function_rust_1.rs",
+        "sample_files/show_function_rust_toplevel.rs",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_c() {
+    assert_function_context(
+        "sample_files/show_function_c_1.c",
+        "sample_files/show_function_c_2.c",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_c_top_level() {
+    assert_no_function_context(
+        "sample_files/show_function_c_1.c",
+        "sample_files/show_function_c_toplevel.c",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_python() {
+    assert_function_context(
+        "sample_files/show_function_python_1.py",
+        "sample_files/show_function_python_2.py",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_python_top_level() {
+    assert_no_function_context(
+        "sample_files/show_function_python_1.py",
+        "sample_files/show_function_python_toplevel.py",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_php() {
+    assert_function_context(
+        "sample_files/show_function_php_1.php",
+        "sample_files/show_function_php_2.php",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_php_top_level() {
+    assert_no_function_context(
+        "sample_files/show_function_php_1.php",
+        "sample_files/show_function_php_toplevel.php",
+        "enclosing_function",
+    );
+}
+
+#[test]
+fn show_function_new_inner_shows_top_level() {
+    // Adding a new inner function should surface the top-level
+    // function's definition, not the new inner one.
+    assert_function_context(
+        "sample_files/show_function_new_inner_1.rs",
+        "sample_files/show_function_new_inner_2.rs",
+        "outer_function",
+    );
+}
+
+#[test]
+fn show_function_renamed() {
+    // Renaming an inner function surfaces the enclosing function.
+    assert_function_context(
+        "sample_files/show_function_rename_1.rs",
+        "sample_files/show_function_rename_2.rs",
+        "top_function",
+    );
+}
+
+#[test]
+fn show_function_deleted() {
+    // Deleting an inner function surfaces the enclosing function.
+    assert_function_context(
+        "sample_files/show_function_delete_1.rs",
+        "sample_files/show_function_delete_2.rs",
+        "top_function",
+    );
+}
+
+#[test]
+fn show_function_nested_single_line() {
+    // Two functions are defined on the same line. --show-function should
+    // surface that single shared definition line (sane output, no panic)
+    // when a change happens inside their body. We use a wide terminal so
+    // the long definition line isn't wrapped, keeping the assertion
+    // robust.
+    let old = "sample_files/show_function_nested_oneline_1.rs";
+    let new = "sample_files/show_function_nested_oneline_2.rs";
+
+    let mut cmd = get_base_command();
+    cmd.arg("--color=never")
+        .arg("--width=200")
+        .arg("--show-function")
+        .arg(old)
+        .arg(new);
+    cmd.assert().success().stdout(predicate::str::contains(
+        "fn outer_oneline() { fn inner_oneline() {",
+    ));
+
+    // Without --show-function, the shared definition line is too far from
+    // the change to be displayed.
+    let mut cmd = get_base_command();
+    cmd.arg("--color=never")
+        .arg("--width=200")
+        .arg(old)
+        .arg(new);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("outer_oneline").not());
+}


### PR DESCRIPTION
Add support for `-p/--show-function`. This mirror's `-p` in `diff`. See #666 

I tested this by running the debug build with `git diff` and checked the output (subset below):

```
❯ DFT_SHOW_FUNCTION=1 git -c diff.external=target/debug/difft diff 49e5cff6b035431421709dc1f74363d8d14638b9 0e7abbcc3dab432fce1bb0f96ef2a86f03d3979e -- src/main.rs
src/main.rs --- 3/9 --- Rust
577 579 fn check_only_text(
595 597         rhs_src: FileContent::Text(rhs_src.into()),
596 598         lhs_positions: vec![],
597 599         rhs_positions: vec![],
... 600         lhs_fn_spans: vec![],
... 601         rhs_fn_spans: vec![],
598 602         hunks: vec![],
599 603         has_byte_changes,
600 604         has_syntactic_changes: lhs_src != rhs_src,

src/main.rs --- 4/9 --- Rust
604 608 fn diff_file_content(
636 640             rhs_src: FileContent::Text("".into()),
637 641             lhs_positions: vec![],
638 642             rhs_positions: vec![],
... 643             lhs_fn_spans: vec![],
... 644             rhs_fn_spans: vec![],
639 645             hunks: vec![],
640 646             has_byte_changes: None,
641 647             has_syntactic_changes: false,
642 648         };
643 649     }
... 650
... 651     // Populated below (only when --show-function is set and we have a
... 652     // tree-sitter parse) and carried into the DiffResult.
... 653     let mut lhs_fn_spans: FunctionSpans = Vec::new();
... 654     let mut rhs_fn_spans: FunctionSpans = Vec::new();
644 655
645 656     let (file_format, lhs_positions, rhs_positions) = match lang_config {
646 657         None => {

src/main.rs --- 5/9 --- Rust
604 608 fn diff_file_content(
684 695                                     rhs_src: FileContent::Text(rhs_src.to_owned()),
685 696                                     lhs_positions: vec![],
686 697                                     rhs_positions: vec![],
... 698                                     lhs_fn_spans: vec![],
... 699                                     rhs_fn_spans: vec![],
687 700                                     hunks: vec![],
688 701                                     has_byte_changes,
689 702                                     has_syntactic_changes,

src/main.rs --- 6/9 --- Rust
604 608 fn diff_file_content(
744 757                                     rhs_positions.extend(rhs_comments);
745 758                                 }
... 759
... 760                                 if display_options.show_function.is_some() {
... 761                                     lhs_fn_spans = tsp::function_spans(&lhs_tree);
... 762                                     rhs_fn_spans = tsp::function_spans(&rhs_tree);
... 763                                 }
746 764
747 765                                 (
748 766                                     FileFormat::SupportedLanguage(language),
```