### PR TITLE
Use a consistent file path label when paths share no suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Improved diffing performance, particularly when diffing directories.
 
 Removed support for SCSS (upstream parser is no longer maintained).
 
+### Display
+
+Fixed an inconsistent choice of file path label when diffing two paths
+that share no common suffix: the label no longer depends on whether the
+files have an extension.
+
 ## 0.69 (released 30th April 2026)
 
 ## Diffing

--- a/src/options.rs
+++ b/src/options.rs
@@ -620,13 +620,10 @@ fn build_display_path(lhs_path: &FileArgument, rhs_path: &FileArgument) -> Strin
 
             match common_path_suffix(lhs, rhs) {
                 Some(common_suffix) => common_suffix,
-                None => {
-                    if rhs.extension().is_some() {
-                        rhs.display().to_string()
-                    } else {
-                        lhs.display().to_string()
-                    }
-                }
+                // No shared path component: use the rhs path consistently,
+                // rather than picking a side based on the file extension
+                // (see #925). This matches the git-tmpfile case above.
+                None => rhs.display().to_string(),
             }
         }
         (FileArgument::NamedPath(p), _) | (_, FileArgument::NamedPath(p)) => {
@@ -1079,5 +1076,24 @@ mod tests {
     fn test_detect_display_width() {
         // Basic smoke test.
         assert!(detect_terminal_width() > 10);
+    }
+
+    #[test]
+    fn test_build_display_path_consistent_without_common_suffix() {
+        // Regression test for #925: when two paths share no common
+        // suffix, the chosen label must not depend on whether the files
+        // have an extension. Use the rhs path consistently.
+        let a = FileArgument::NamedPath(PathBuf::from("a"));
+        let b = FileArgument::NamedPath(PathBuf::from("b"));
+        let a_txt = FileArgument::NamedPath(PathBuf::from("a.txt"));
+        let b_txt = FileArgument::NamedPath(PathBuf::from("b.txt"));
+
+        assert_eq!(build_display_path(&a, &b), "b");
+        assert_eq!(build_display_path(&a_txt, &b_txt), "b.txt");
+
+        // A shared trailing component is still used when present.
+        let dir1 = FileArgument::NamedPath(PathBuf::from("dir1/foo.txt"));
+        let dir2 = FileArgument::NamedPath(PathBuf::from("dir2/foo.txt"));
+        assert_eq!(build_display_path(&dir1, &dir2), "foo.txt");
     }
 }


### PR DESCRIPTION
## what

When diffing two files whose paths share no common trailing component, the path shown in the hunk header depends on whether the files have an extension:

```
$ difft a b
a --- Text
$ difft a.txt b.txt
b.txt --- Text
```

`a` vs `b` labels with the left path, but `a.txt` vs `b.txt` labels with the right path. This is #925.

## why

`build_display_path`'s no-common-suffix arm picked the rhs path when rhs had an extension and the lhs path otherwise:

```rust
None => {
    if rhs.extension().is_some() {
        rhs.display().to_string()
    } else {
        lhs.display().to_string()
    }
}
```

so the side shown was driven by the extension.

## fix

Use the rhs path consistently here, matching the git-tmpfile branch just above (which already returns rhs) and the usual convention of showing the new/destination file.

```rust
None => rhs.display().to_string(),
```

The change is scoped to that one match arm. The reporter also suggested detecting a rename and showing both paths; that is a larger behaviour change, so I kept this minimal and easy to extend if you would rather take the show-both approach.

## tests

`test_build_display_path_consistent_without_common_suffix` covers the extensionless and extensioned cases (both now use rhs) and the shared-suffix case (unchanged). It fails before the fix and passes after. Full suite green.

Fixes #925.
