### PR TITLE
Don't emit hunks with no novel lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Improved diffing performance, particularly when diffing directories.
 
+Fixed a crash when line reordering left a hunk with no novel lines
+(#995).
+
 ### Parsing
 
 Removed support for SCSS (upstream parser is no longer maintained).

--- a/sample_files/cli_tests/empty_hunk_1.py
+++ b/sample_files/cli_tests/empty_hunk_1.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+from typing import Any
+
+
+def create_app_from_runtime_config() -> Any:
+    config = load_runtime_config()
+    repo_root = (
+        Path(config.repo_root).expanduser() if config.repo_root else None
+    )
+    repo = GitBackend.discover(repo_root=repo_root)
+    presets_root = (
+        Path(config.presets_root).expanduser() if config.presets_root else None
+    )
+    preset_repo = PresetBackend.discover(presets_root=presets_root)
+    service = TextDiffService(repo)
+    git_service = GitDiffService(repo)
+    difftastic_service = DifftasticDiffService(repo)
+    preset_service = TextDiffService(preset_repo)
+    preset_git_service = GitDiffService(preset_repo)
+    preset_difftastic_service = DifftasticDiffService(preset_repo)
+    defaults = build_defaults(
+        service,
+        left=config.left,
+        right=config.right,
+        base_branch=config.base_branch,
+        review_branch=config.review_branch,
+    )
+    return create_app(
+        service,
+        defaults,
+        services={"git": git_service, "difftastic": difftastic_service},
+        preset_services={
+            "dirdiff": preset_service,
+            "git": preset_git_service,
+            "difftastic": preset_difftastic_service,
+        },
+    )

--- a/sample_files/cli_tests/empty_hunk_2.py
+++ b/sample_files/cli_tests/empty_hunk_2.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+
+
+def create_app_from_runtime_config() -> FastAPI:
+    config = load_runtime_config()
+    store = RepoMarkStore.open(Path(config.db_path))
+
+    marks = store.list()
+    if len(marks) == 0:
+        raise SystemExit(
+            "No marked repos. Run: dirdiff mark /path/to/repo "
+            "--db-path /path/to/db.sqlite"
+        )
+    return create_app(store, presets_root=config.presets_root)
+
+
+def handle_mark_command(args: argparse.Namespace) -> None:
+    store = RepoMarkStore.open(Path(args.db_path))
+    repo_path = Path(args.repo_path)
+    if args.name is None:
+        resolved_path = repo_path.expanduser().resolve()
+        display_name = resolved_path.name
+        if not display_name:
+            raise SystemExit(
+                f"Cannot derive a repo name from path: {resolved_path}"
+            )
+    else:
+        display_name = args.name
+    try:
+        mark = store.mark(RepoMarkInput(path=repo_path, name=display_name))
+    except RepoRegistryError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(f"Marked repo {mark.id}: {mark.path}", file=sys.stderr)

--- a/src/display/hunks.rs
+++ b/src/display/hunks.rs
@@ -317,11 +317,17 @@ fn lines_to_hunks(
         } else {
             let (novel_lhs, novel_rhs) =
                 find_novel_lines(&current_hunk_lines, &all_lhs_novel, &all_rhs_novel);
-            hunks.push(Hunk {
-                novel_lhs,
-                novel_rhs,
-                lines: current_hunk_lines,
-            });
+            // A hunk must contain at least one novel line. `enforce_increasing`
+            // can strip the novel side of a line pair when it occurs out of
+            // order, leaving only matched (non-novel) lines behind. Such a
+            // group represents no change, so don't emit it as a hunk.
+            if !novel_lhs.is_empty() || !novel_rhs.is_empty() {
+                hunks.push(Hunk {
+                    novel_lhs,
+                    novel_rhs,
+                    lines: current_hunk_lines,
+                });
+            }
             current_hunk_lines = vec![line];
         }
 
@@ -336,11 +342,13 @@ fn lines_to_hunks(
     if !current_hunk_lines.is_empty() {
         let (novel_lhs, novel_rhs) =
             find_novel_lines(&current_hunk_lines, &all_lhs_novel, &all_rhs_novel);
-        hunks.push(Hunk {
-            novel_lhs,
-            novel_rhs,
-            lines: current_hunk_lines,
-        });
+        if !novel_lhs.is_empty() || !novel_rhs.is_empty() {
+            hunks.push(Hunk {
+                novel_lhs,
+                novel_rhs,
+                lines: current_hunk_lines,
+            });
+        }
     }
 
     hunks

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -137,6 +137,21 @@ fn text_changes_at_end_doesnt_crash() {
     cmd.assert().success();
 }
 
+/// Regression test for https://github.com/Wilfred/difftastic/issues/995.
+///
+/// When line reordering strips the novel side from every line pair in a
+/// group, the resulting hunk has no novel lines, which used to panic with
+/// "Hunk lines should be present in matched lines".
+#[test]
+fn empty_novel_hunk_doesnt_crash() {
+    let mut cmd = get_base_command();
+
+    cmd.arg("sample_files/cli_tests/empty_hunk_1.py")
+        .arg("sample_files/cli_tests/empty_hunk_2.py");
+
+    cmd.assert().success();
+}
+
 #[test]
 fn makefile_text_as_atom() {
     let mut cmd = get_base_command();


### PR DESCRIPTION
Fixes #995.

`difft old.py new.py` on the files in the report panics:

```
thread 'main' panicked at src/display/hunks.rs:667:31:
Hunk lines should be present in matched lines
```

### What's happening

`matched_novel_lines` pairs each novel line with the matched line opposite it, e.g. `(Some(novel_lhs), Some(opposite_rhs))`. `lines_to_hunks` then runs the pairs through `enforce_increasing`, which replaces a line number with `None` when it occurs out of order. When the novel side of a pair is the one discarded, only the matched (non-novel) line is left behind, e.g. `(None, Some(opposite_rhs))`.

A run of these stripped pairs can form an entire hunk. `find_novel_lines` finds nothing novel in it, so the hunk's `novel_lhs` and `novel_rhs` are both empty. `matched_lines_indexes_for_hunk` then searches `matched_lines` for the hunk's smallest and largest novel line, gets `(None, None)` for both, and `either_side_equal` is never true, so the `expect` at hunks.rs:667 fires.

I confirmed this against the panic site by printing the hunk and matched lines:

```
hunk_smallest=(None, None) hunk_largest=(None, None)
novel_lhs_sorted=[] novel_rhs_sorted=[]
start_i=None end_i=None
```

### The fix

A hunk with no novel lines represents no change, so it shouldn't be produced in the first place. This skips emitting a hunk when both novel sets are empty, which keeps the invariant that `matched_lines_indexes_for_hunk` already relies on.

### Test

Added `empty_novel_hunk_doesnt_crash` to `tests/cli.rs`, using the two files from the report as fixtures. It panics on `master` and passes with this change. The existing unit and CLI tests still pass.

Thanks to @juliancoffee for the clear repro; their fork had a similar observation about the empty-hunk case.