### PR TITLE
Support OSC-1717 metadata

### DIFF
--- a/src/display/diff_line_metadata.rs
+++ b/src/display/diff_line_metadata.rs
@@ -60,6 +60,16 @@ fn handshake_for_version(version: u32) -> String {
     format!("{OSC};{version}{ST}")
 }
 
+/// [`DiffLineMetadata::hunkless_banner`] for callers outside the per-hunk
+/// display paths: returns `banner` with every row tagged by the file's `f`
+/// record, or unchanged when no host negotiated a version.
+pub(crate) fn tag_hunkless_file_banner(file: &str, banner: &str) -> String {
+    match DiffLineMetadata::from_env(file) {
+        Some(md) => md.hunkless_banner(banner),
+        None => banner.to_owned(),
+    }
+}
+
 /// The highest version in the host's advertised list (e.g. "V1" or "V1,V2")
 /// that this build also understands, or `None` if the lists are disjoint.
 fn pick_version(advertised: &str) -> Option<u32> {
@@ -194,17 +204,38 @@ impl DiffLineMetadata {
     ) -> String {
         let mut prefix = String::new();
         if is_first_hunk {
-            prefix.push_str(&format!(
-                "{OSC};{version};f;;;{file}{ST}",
-                version = self.version,
-                file = self.file,
-            ));
+            prefix.push_str(&self.file_record());
         }
         prefix.push_str(&self.osc('h', new_line, None));
         format!(
             "{}{}",
             prefix,
             banner.replace('\n', &format!("\n{}", prefix))
+        )
+    }
+
+    /// Prefix every row of a banner with the file's `f` record alone, for a
+    /// file that renders no hunks: a binary file, a file whose changes
+    /// produce no hunk rows, or an unchanged file under `--print-unchanged`.
+    /// Files with no content lines still emit their `f` so they stay visible
+    /// to the identity layer -- a host's file list and file navigation
+    /// include them (spec §5.5). There is no hunk to announce, so no `h`.
+    pub(crate) fn hunkless_banner(&self, banner: &str) -> String {
+        let record = self.file_record();
+        format!(
+            "{}{}",
+            record,
+            banner.replace('\n', &format!("\n{}", record))
+        )
+    }
+
+    /// The `f` record: the file's identity, never carrying line numbers
+    /// (spec §5.5).
+    fn file_record(&self) -> String {
+        format!(
+            "{OSC};{version};f;;;{file}{ST}",
+            version = self.version,
+            file = self.file,
         )
     }
 
@@ -339,6 +370,31 @@ mod tests {
             md.header_banner(true, 1, "new.txt --- Rust\nrenamed from old.txt"),
             "\x1b]1717;1;f;;;a/b.txt\x1b\\\x1b]1717;1;h;1;;a/b.txt\x1b\\new.txt --- Rust\n\
              \x1b]1717;1;f;;;a/b.txt\x1b\\\x1b]1717;1;h;1;;a/b.txt\x1b\\renamed from old.txt"
+        );
+    }
+
+    #[test]
+    fn test_hunkless_banner_carries_f_only() {
+        // A file that renders no hunks -- a binary file, or a hunk-less
+        // change -- still emits its `f` so it stays visible to the identity
+        // layer (spec §5.5). There is no hunk, so no `h`, and an `f` never
+        // carries line numbers.
+        let md = metadata();
+        assert_eq!(
+            md.hunkless_banner("b.txt --- Binary"),
+            "\x1b]1717;1;f;;;a/b.txt\x1b\\b.txt --- Binary"
+        );
+    }
+
+    #[test]
+    fn test_hunkless_banner_tags_every_row() {
+        // A renamed binary file's banner spans two rows; each row of the
+        // header block carries the same record (spec §6.4).
+        let md = metadata();
+        assert_eq!(
+            md.hunkless_banner("new.bin --- Binary\nrenamed from old.bin"),
+            "\x1b]1717;1;f;;;a/b.txt\x1b\\new.bin --- Binary\n\
+             \x1b]1717;1;f;;;a/b.txt\x1b\\renamed from old.bin"
         );
     }
 

--- a/src/display/diff_line_metadata.rs
+++ b/src/display/diff_line_metadata.rs
@@ -1,0 +1,300 @@
+//! Emit per-line diff metadata as an OSC sequence, so that a host application
+//! (e.g. lazygit) can map a rendered diff cell back to its patch-space identity
+//! (file, line type, new-file line, old-file line) without re-parsing the
+//! rendered output. difftastic produces a structural, non-unified rendering --
+//! side-by-side columns by default, no `@@`/`+`/`-` markers -- so that identity
+//! cannot be recovered from the painted text at all. The pager, which still has
+//! it at render time, states it.
+//!
+//! The metadata is attached **per cell**: in side-by-side mode the old-file
+//! (left) column carries the deleted/old line's identity and the new-file
+//! (right) column the added/new line's, so a single rendered row can carry two
+//! records. A host reads the nearest record to the left of the point it cares
+//! about, knowing only "left column / right column", never difftastic's layout.
+//! When side-by-side collapses a hunk to a single column, a modified row still
+//! represents both patch lines; its `d` and `a` records are then emitted
+//! back-to-back at the row's start (the `d` region is zero-width -- spec
+//! §6.2), so a host acting on the row still sees both halves.
+//!
+//! This is gated on the `OSC1717` environment variable: the host advertises the
+//! protocol versions it understands and difftastic emits the highest mutually-
+//! understood one. When the variable is unset (i.e. difftastic is not running
+//! under such a host) nothing is emitted, so a raw terminal / less / tmux see a
+//! normal diff.
+//!
+//! The OSC number 1717 was chosen after auditing the OSC allocations of the major
+//! terminal emulators (xterm, VTE, kitty, foot, WezTerm, iTerm2, Windows Terminal,
+//! Ghostty, VS Code, ConEmu, urxvt); none of them interpret it, so a terminal that
+//! is not a participating host skips it harmlessly.
+
+use std::sync::OnceLock;
+
+use line_numbers::LineNumber;
+
+use crate::constants::Side;
+
+/// Highest protocol version this build of difftastic knows how to emit.
+const SUPPORTED_VERSION: u32 = 1;
+
+const OSC: &str = "\x1b]1717";
+const ST: &str = "\x1b\\";
+
+/// The protocol version to emit, negotiated against the host's advertised list
+/// in `OSC1717` (e.g. "V1" or "V1,V2"), or `None` when no host is asking (the
+/// variable is unset) so difftastic stays silent.
+pub(crate) fn negotiated_version() -> Option<u32> {
+    static VERSION: OnceLock<Option<u32>> = OnceLock::new();
+    *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717").ok()?))
+}
+
+/// The highest version in the host's advertised list (e.g. "V1" or "V1,V2")
+/// that this build also understands, or `None` if the lists are disjoint.
+fn pick_version(advertised: &str) -> Option<u32> {
+    advertised
+        .split(',')
+        .filter_map(|v| v.trim().strip_prefix('V')?.parse::<u32>().ok())
+        .filter(|v| *v <= SUPPORTED_VERSION)
+        .max()
+}
+
+/// Whether an aligned row is a change in patch space: one side is absent (a
+/// pure addition/deletion), or the two sides' contents differ.
+///
+/// Token-level novelty is deliberately NOT the test here. The records name
+/// git's line-granular model (a modified line is a `d` plus an `a` -- spec
+/// §5.1), but difftastic's novelty is per token: a line changed only by
+/// *added* tokens has no novel old-side tokens at all, and a blank line has no
+/// tokens to be novel. Classifying by novel-token sets tagged such old lines
+/// `c`, so a host staging by the records dropped the deletion half of the
+/// modification (or, mirrored, the addition half). Comparing the aligned
+/// lines' contents recovers the patch-space type; genuinely identical lines
+/// that merely fall inside a hunk still compare equal and stay `c`.
+pub(crate) fn row_is_novel(
+    lhs_line: Option<LineNumber>,
+    rhs_line: Option<LineNumber>,
+    lhs_lines: &[&str],
+    rhs_lines: &[&str],
+) -> bool {
+    match (lhs_line, rhs_line) {
+        (Some(lhs_line), Some(rhs_line)) => {
+            lhs_lines.get(lhs_line.as_usize()) != rhs_lines.get(rhs_line.as_usize())
+        }
+        _ => true,
+    }
+}
+
+/// Formats the per-cell diff-metadata OSC sequences for a file's rendered diff.
+///
+/// One instance is created per file (the `file` field is fixed for its
+/// lifetime). Only constructed when a host negotiated a version via `OSC1717`;
+/// otherwise `from_env` returns `None` and the display code emits nothing,
+/// leaving difftastic's output byte-for-byte unchanged.
+pub(crate) struct DiffLineMetadata {
+    version: u32,
+    file: String,
+}
+
+impl DiffLineMetadata {
+    pub(crate) fn from_env(file: &str) -> Option<Self> {
+        negotiated_version().map(|version| Self {
+            version,
+            file: file.to_owned(),
+        })
+    }
+
+    /// OSC for the old-file (left) column cell of an aligned row, or `""` when
+    /// there is no left content (the blank left half of a pure addition). A
+    /// novel old line (novel in patch space -- see [`row_is_novel`]) is a
+    /// deletion (`d`, carrying both line numbers); a non-novel one is context
+    /// (`c`).
+    ///
+    /// `new_line` is the new-file position this old line sits at: the aligned
+    /// new line when the row has one (a modification, or a context line shown on
+    /// both sides), else the next new-file line after `prev_rhs`. A pure
+    /// deletion has no new-file line of its own, so it sits at the position the
+    /// following new line will occupy -- mirroring `patch.LineNumberOfLine` and
+    /// delta's deletion convention. (difftastic, unlike a unified-diff pager,
+    /// keeps no linear new-file counter; the previous aligned new line is the
+    /// only thing it has to derive this from.)
+    pub(crate) fn left_cell(
+        &self,
+        lhs_line: Option<LineNumber>,
+        rhs_line: Option<LineNumber>,
+        novel: bool,
+        prev_rhs: Option<LineNumber>,
+    ) -> String {
+        let Some(lhs_line) = lhs_line else {
+            return String::new();
+        };
+        let new_line = match rhs_line {
+            Some(rhs_line) => rhs_line.as_usize() + 1,
+            None => prev_rhs.map_or(1, |n| n.as_usize() + 2),
+        };
+        if novel {
+            self.osc('d', new_line, Some(lhs_line.as_usize() + 1))
+        } else {
+            self.osc('c', new_line, None)
+        }
+    }
+
+    /// OSC for the new-file (right) column cell of an aligned row, or `""` when
+    /// there is no right content (the blank right half of a pure deletion). A
+    /// novel new line (novel in patch space -- see [`row_is_novel`]) is an
+    /// addition (`a`); a non-novel one is context (`c`).
+    pub(crate) fn right_cell(&self, rhs_line: Option<LineNumber>, novel: bool) -> String {
+        let Some(rhs_line) = rhs_line else {
+            return String::new();
+        };
+        let type_char = if novel { 'a' } else { 'c' };
+        self.osc(type_char, rhs_line.as_usize() + 1, None)
+    }
+
+    /// OSC for a line of a single-column whole-file addition or deletion (the
+    /// path difftastic takes when one side is empty). Every line is novel: a
+    /// right column is all additions, a left column all deletions. A deleted
+    /// file has no new-file content, so its deletions sit at new-line 0 (as
+    /// delta emits for `@@ -1,N +0,0 @@`).
+    pub(crate) fn single_column_cell(&self, side: Side, line_idx: usize) -> String {
+        match side {
+            Side::Right => self.osc('a', line_idx + 1, None),
+            Side::Left => self.osc('d', 0, Some(line_idx + 1)),
+        }
+    }
+
+    fn osc(&self, type_char: char, new_line: usize, old_line: Option<usize>) -> String {
+        let old_field = old_line.map_or(String::new(), |n| n.to_string());
+        format!(
+            "{OSC};{version};{type_char};{new_line};{old_field};{file}{ST}",
+            version = self.version,
+            file = self.file,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> DiffLineMetadata {
+        DiffLineMetadata {
+            version: 1,
+            file: "a/b.txt".to_owned(),
+        }
+    }
+
+    #[test]
+    fn test_pick_version() {
+        assert_eq!(pick_version("V1"), Some(1));
+        assert_eq!(pick_version("V1,V2"), Some(1)); // we cap at SUPPORTED_VERSION
+        assert_eq!(pick_version("V2,V3"), None); // disjoint with what we emit
+        assert_eq!(pick_version(""), None);
+        assert_eq!(pick_version("garbage"), None);
+    }
+
+    #[test]
+    fn test_context_line_is_symmetric() {
+        // An unchanged line aligned on both sides: the same `c` record (keyed on
+        // the new-file line) is emitted before each column's cell.
+        let md = metadata();
+        let left = md.left_cell(Some(2.into()), Some(2.into()), false, None);
+        let right = md.right_cell(Some(2.into()), false);
+        assert_eq!(left, "\x1b]1717;1;c;3;;a/b.txt\x1b\\");
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn test_modification_splits_into_delete_and_add() {
+        // `old(3)` -> `new(3)`: the left cell is the deletion (both numbers),
+        // the right cell the addition (new number only).
+        let md = metadata();
+        assert_eq!(
+            md.left_cell(Some(2.into()), Some(2.into()), true, None),
+            "\x1b]1717;1;d;3;3;a/b.txt\x1b\\"
+        );
+        assert_eq!(
+            md.right_cell(Some(2.into()), true),
+            "\x1b]1717;1;a;3;;a/b.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_pure_deletion_new_line_follows_previous_new_line() {
+        // A deletion has no new-file line of its own; it sits at the new-file
+        // position the next new line will take (previous new line + 1).
+        let md = metadata();
+        // previous new line was the 1-based line 1 (0-based 0) -> deletion at 2.
+        assert_eq!(
+            md.left_cell(Some(1.into()), None, true, Some(0.into())),
+            "\x1b]1717;1;d;2;2;a/b.txt\x1b\\"
+        );
+        // No previous new line (deletion before any new content) -> 1.
+        assert_eq!(
+            md.left_cell(Some(0.into()), None, true, None),
+            "\x1b]1717;1;d;1;1;a/b.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_pure_addition_and_blank_counterpart() {
+        let md = metadata();
+        assert_eq!(
+            md.right_cell(Some(4.into()), true),
+            "\x1b]1717;1;a;5;;a/b.txt\x1b\\"
+        );
+        // The blank counterpart half of a pure add/delete carries no metadata.
+        assert_eq!(md.left_cell(None, Some(4.into()), false, None), "");
+        assert_eq!(md.right_cell(None, false), "");
+    }
+
+    #[test]
+    fn test_whole_file_single_column() {
+        let md = metadata();
+        assert_eq!(
+            md.single_column_cell(Side::Right, 0),
+            "\x1b]1717;1;a;1;;a/b.txt\x1b\\"
+        );
+        // A deleted file has no new-file content, so deletions sit at new-line 0.
+        assert_eq!(
+            md.single_column_cell(Side::Left, 0),
+            "\x1b]1717;1;d;0;1;a/b.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_row_is_novel_compares_contents_not_tokens() {
+        let lhs_lines = ["foo(1)", "", "same"];
+        let rhs_lines = ["foo(1, 0)", "same"];
+
+        // A modification whose change is only added tokens: the old line has no
+        // novel tokens, but the contents differ, so the row is a change.
+        assert!(row_is_novel(
+            Some(0.into()),
+            Some(0.into()),
+            &lhs_lines,
+            &rhs_lines
+        ));
+        // One-sided rows are always changes -- including blank lines, which
+        // have no tokens at all.
+        assert!(row_is_novel(Some(1.into()), None, &lhs_lines, &rhs_lines));
+        assert!(row_is_novel(None, Some(1.into()), &lhs_lines, &rhs_lines));
+        // An identical line that merely sits inside a hunk stays context.
+        assert!(!row_is_novel(
+            Some(2.into()),
+            Some(1.into()),
+            &lhs_lines,
+            &rhs_lines
+        ));
+    }
+
+    #[test]
+    fn test_path_is_last_field_so_it_may_contain_semicolons() {
+        let md = DiffLineMetadata {
+            version: 1,
+            file: "weird;name.txt".to_owned(),
+        };
+        assert_eq!(
+            md.right_cell(Some(0.into()), true),
+            "\x1b]1717;1;a;1;;weird;name.txt\x1b\\"
+        );
+    }
+}

--- a/src/display/diff_line_metadata.rs
+++ b/src/display/diff_line_metadata.rs
@@ -174,6 +174,40 @@ impl DiffLineMetadata {
         }
     }
 
+    /// Prefix every row of a header banner with its OSC record(s). difftastic
+    /// renders no `@@`/`diff --git` rows; instead it prints one banner per hunk
+    /// (`path --- N/total --- Format`) that announces both the file and the
+    /// hunk. Every banner is a hunk header, so it carries that hunk's `h`
+    /// record (`new_line` is the hunk's first new-file line); the first hunk's
+    /// banner is also the only row announcing the file, so it additionally
+    /// carries the file's `f` record -- before the `h`, per the combined-header
+    /// rule (spec §5.5). An `f` never carries line numbers.
+    ///
+    /// The banner is one row, or two when the first hunk also shows a rename's
+    /// old path -- and spec §6.4 wants every row of a header block tagged, so
+    /// each row gets the same record(s).
+    pub(crate) fn header_banner(
+        &self,
+        is_first_hunk: bool,
+        new_line: usize,
+        banner: &str,
+    ) -> String {
+        let mut prefix = String::new();
+        if is_first_hunk {
+            prefix.push_str(&format!(
+                "{OSC};{version};f;;;{file}{ST}",
+                version = self.version,
+                file = self.file,
+            ));
+        }
+        prefix.push_str(&self.osc('h', new_line, None));
+        format!(
+            "{}{}",
+            prefix,
+            banner.replace('\n', &format!("\n{}", prefix))
+        )
+    }
+
     fn osc(&self, type_char: char, new_line: usize, old_line: Option<usize>) -> String {
         let old_field = old_line.map_or(String::new(), |n| n.to_string());
         format!(
@@ -277,6 +311,34 @@ mod tests {
         assert_eq!(
             md.single_column_cell(Side::Left, 0),
             "\x1b]1717;1;d;0;1;a/b.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_header_banner_file_and_hunk() {
+        // Every banner is a hunk header (`h`, carrying the hunk's first line);
+        // the first hunk's banner also announces the file, so it additionally
+        // carries the `f` record -- first, and without line numbers (spec §5.5).
+        let md = metadata();
+        assert_eq!(
+            md.header_banner(true, 1, "b.txt --- Rust"),
+            "\x1b]1717;1;f;;;a/b.txt\x1b\\\x1b]1717;1;h;1;;a/b.txt\x1b\\b.txt --- Rust"
+        );
+        assert_eq!(
+            md.header_banner(false, 16, "b.txt --- 2/2 --- Rust"),
+            "\x1b]1717;1;h;16;;a/b.txt\x1b\\b.txt --- 2/2 --- Rust"
+        );
+    }
+
+    #[test]
+    fn test_header_banner_tags_every_row() {
+        // A rename's first-hunk banner spans two rows (path, then old path);
+        // each row carries the same records (spec §6.4).
+        let md = metadata();
+        assert_eq!(
+            md.header_banner(true, 1, "new.txt --- Rust\nrenamed from old.txt"),
+            "\x1b]1717;1;f;;;a/b.txt\x1b\\\x1b]1717;1;h;1;;a/b.txt\x1b\\new.txt --- Rust\n\
+             \x1b]1717;1;f;;;a/b.txt\x1b\\\x1b]1717;1;h;1;;a/b.txt\x1b\\renamed from old.txt"
         );
     }
 

--- a/src/display/diff_line_metadata.rs
+++ b/src/display/diff_line_metadata.rs
@@ -47,6 +47,19 @@ pub(crate) fn negotiated_version() -> Option<u32> {
     *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717").ok()?))
 }
 
+/// The handshake record: a version-only OSC 1717 (no further fields) that a
+/// conforming pager emits once, as its first output, to announce it speaks the
+/// protocol (see the spec, §4.4). It lets a host probe difftastic on an empty diff
+/// — which emits no per-line records — and tell "speaks the protocol" apart from
+/// "unsupported pager". Empty when no host negotiated a version.
+pub(crate) fn handshake() -> String {
+    negotiated_version().map_or(String::new(), handshake_for_version)
+}
+
+fn handshake_for_version(version: u32) -> String {
+    format!("{OSC};{version}{ST}")
+}
+
 /// The highest version in the host's advertised list (e.g. "V1" or "V1,V2")
 /// that this build also understands, or `None` if the lists are disjoint.
 fn pick_version(advertised: &str) -> Option<u32> {
@@ -189,6 +202,13 @@ mod tests {
         assert_eq!(pick_version("V2,V3"), None); // disjoint with what we emit
         assert_eq!(pick_version(""), None);
         assert_eq!(pick_version("garbage"), None);
+    }
+
+    #[test]
+    fn test_handshake_is_version_only() {
+        // The handshake carries only the version (no further fields), so a host tells
+        // it apart from a per-line record by field count.
+        assert_eq!(handshake_for_version(1), "\x1b]1717;1\x1b\\");
     }
 
     #[test]

--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -76,18 +76,6 @@ pub(crate) fn print(
     let rhs_line_nums_width = format_line_num(rhs_src.max_line()).len();
 
     for (i, hunk) in hunks.iter().enumerate() {
-        println!(
-            "{}",
-            style::header(
-                display_path,
-                extra_info.as_ref(),
-                i + 1,
-                hunks.len(),
-                file_format,
-                display_options
-            )
-        );
-
         let hunk_lines = hunk.lines.clone();
 
         let before_lines = calculate_before_context(
@@ -105,6 +93,30 @@ pub(crate) fn print(
             rhs_src.max_line(),
             display_options.num_context_lines as usize,
         );
+
+        let banner = style::header(
+            display_path,
+            extra_info.as_ref(),
+            i + 1,
+            hunks.len(),
+            file_format,
+            display_options,
+        );
+        match &metadata {
+            // The banner announces both the file and this hunk: every banner
+            // carries the hunk's `h` (with the hunk's first new-file line), and
+            // the first hunk's banner additionally carries the file's `f`.
+            Some(metadata) => {
+                let new_line = before_lines
+                    .iter()
+                    .chain(hunk_lines.iter())
+                    .chain(after_lines.iter())
+                    .find_map(|(_, rhs)| rhs.map(|n| n.as_usize() + 1))
+                    .unwrap_or(1);
+                println!("{}", metadata.header_banner(i == 0, new_line, &banner));
+            }
+            None => println!("{}", banner),
+        }
 
         // Inline mode groups all old-side content (before-context, then
         // deletions) before all new-side content (additions, then

--- a/src/display/inline.rs
+++ b/src/display/inline.rs
@@ -1,9 +1,12 @@
 //! Inline, or "unified" diff display.
 
+use line_numbers::LineNumber;
+
 use crate::constants::Side;
 use crate::display::context::{
     calculate_after_context, calculate_before_context, opposite_positions,
 };
+use crate::display::diff_line_metadata::{row_is_novel, DiffLineMetadata};
 use crate::display::hunks::Hunk;
 use crate::display::style::{self, apply_colors, apply_line_number_color};
 use crate::lines::{format_line_num, format_line_num_padded, split_on_newlines, MaxLine};
@@ -64,6 +67,10 @@ pub(crate) fn print(
     let opposite_to_lhs = opposite_positions(lhs_mps);
     let opposite_to_rhs = opposite_positions(rhs_mps);
 
+    let metadata = DiffLineMetadata::from_env(display_path);
+    let lhs_lines: Vec<&str> = split_on_newlines(lhs_src).collect();
+    let rhs_lines: Vec<&str> = split_on_newlines(rhs_src).collect();
+
     // Calculate the maximum line number width for alignment
     let lhs_line_nums_width = format_line_num(lhs_src.max_line()).len();
     let rhs_line_nums_width = format_line_num(rhs_src.max_line()).len();
@@ -99,8 +106,31 @@ pub(crate) fn print(
             display_options.num_context_lines as usize,
         );
 
-        for (lhs_line, _) in before_lines {
+        // Inline mode groups all old-side content (before-context, then
+        // deletions) before all new-side content (additions, then
+        // after-context). The metadata rides each line: the old-side passes
+        // emit the left-column record, the new-side passes the right-column
+        // one, so a host can still reconstruct each line's identity despite the
+        // grouping. `prev_rhs` carries the most recent new-file line through the
+        // old-side passes, to place a pure deletion (which has no new line of
+        // its own) at the following new-file position.
+        let mut prev_rhs: Option<LineNumber> = None;
+
+        for (lhs_line, rhs_line) in before_lines {
             if let Some(lhs_line) = lhs_line {
+                if let Some(metadata) = &metadata {
+                    // An old line with no new-side counterpart is a deletion in
+                    // patch space even when this display files it under context
+                    // (a deleted blank line, or a line consumed by a join). An
+                    // aligned context row stays `c` even if its sides' contents
+                    // differ (a whitespace-only change): only one side of it is
+                    // ever rendered here, so a `d` would hand the host a
+                    // deletion whose addition it can never show.
+                    print!(
+                        "{}",
+                        metadata.left_cell(Some(lhs_line), rhs_line, rhs_line.is_none(), prev_rhs,)
+                    );
+                }
                 print!(
                     "{}   {}",
                     apply_line_number_color(
@@ -112,10 +142,31 @@ pub(crate) fn print(
                     lhs_colored_lines[lhs_line.as_usize()]
                 );
             }
+            if let Some(rhs_line) = rhs_line {
+                prev_rhs = Some(rhs_line);
+            }
         }
 
-        for (lhs_line, _) in &hunk_lines {
+        for (lhs_line, rhs_line) in &hunk_lines {
             if let Some(lhs_line) = lhs_line {
+                if let Some(metadata) = &metadata {
+                    // The line type is the row's patch-space type (contents
+                    // compared -- see row_is_novel), not the token novelty the
+                    // display colors by: a line changed only by added tokens
+                    // has no novel old-side tokens, yet its old line is still
+                    // the deletion half of the modification. A genuinely
+                    // identical line that falls inside the hunk still compares
+                    // equal and is tagged c.
+                    print!(
+                        "{}",
+                        metadata.left_cell(
+                            Some(*lhs_line),
+                            *rhs_line,
+                            row_is_novel(Some(*lhs_line), *rhs_line, &lhs_lines, &rhs_lines),
+                            prev_rhs,
+                        )
+                    );
+                }
                 print!(
                     "{}   {}",
                     apply_line_number_color(
@@ -127,9 +178,21 @@ pub(crate) fn print(
                     lhs_colored_lines[lhs_line.as_usize()]
                 );
             }
-        }
-        for (_, rhs_line) in &hunk_lines {
             if let Some(rhs_line) = rhs_line {
+                prev_rhs = Some(*rhs_line);
+            }
+        }
+        for (lhs_line, rhs_line) in &hunk_lines {
+            if let Some(rhs_line) = rhs_line {
+                if let Some(metadata) = &metadata {
+                    print!(
+                        "{}",
+                        metadata.right_cell(
+                            Some(*rhs_line),
+                            row_is_novel(*lhs_line, Some(*rhs_line), &lhs_lines, &rhs_lines),
+                        )
+                    );
+                }
                 print!(
                     "   {}{}",
                     apply_line_number_color(
@@ -143,8 +206,18 @@ pub(crate) fn print(
             }
         }
 
-        for (_, rhs_line) in &after_lines {
+        for (lhs_line, rhs_line) in &after_lines {
             if let Some(rhs_line) = rhs_line {
+                if let Some(metadata) = &metadata {
+                    // Mirror of the before-context pass: a new line with no
+                    // old-side counterpart is an addition even when filed under
+                    // context; an aligned context row stays `c` regardless of
+                    // content.
+                    print!(
+                        "{}",
+                        metadata.right_cell(Some(*rhs_line), lhs_line.is_none())
+                    );
+                }
                 print!(
                     "   {}{}",
                     apply_line_number_color(

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod context;
+pub(crate) mod diff_line_metadata;
 pub(crate) mod hunks;
 pub(crate) mod inline;
 pub(crate) mod json;

--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -81,15 +81,18 @@ fn display_single_column(
 
     let mut formatted_lines = Vec::with_capacity(src_lines.len());
 
-    let mut header_line = String::new();
-    header_line.push_str(&style::header(
-        display_path,
-        old_path,
-        1,
-        1,
-        file_format,
-        display_options,
-    ));
+    let banner = style::header(display_path, old_path, 1, 1, file_format, display_options);
+    let mut header_line = match metadata {
+        // A whole-file add/delete is a single hunk, so its banner carries the
+        // file's `f` and the hunk's `h`. A deleted file has no new-file
+        // content, so its hunk sits at new-line 0 (as for its deletion
+        // records); an added file's first new line is 1.
+        Some(metadata) => {
+            let new_line = if side == Side::Right { 1 } else { 0 };
+            metadata.header_banner(true, new_line, &banner)
+        }
+        None => banner,
+    };
     header_line.push('\n');
     formatted_lines.push(header_line);
 
@@ -426,6 +429,21 @@ fn visible_content_max_display_width(
     (lhs_content_max_width, rhs_content_max_width)
 }
 
+/// The new-file line a hunk's header banner points at: the first new-file
+/// (RHS) line shown in the hunk (spec §5.2). A hunk with no new-file lines at
+/// all (a pure deletion with no surrounding new context) falls back to the
+/// position the next new line would occupy, mirroring the deletion convention
+/// in `left_cell`.
+fn hunk_first_new_line(
+    aligned_lines: &[(Option<LineNumber>, Option<LineNumber>)],
+    prev_rhs: Option<LineNumber>,
+) -> usize {
+    aligned_lines
+        .iter()
+        .find_map(|(_, rhs)| rhs.map(|n| n.as_usize() + 1))
+        .unwrap_or_else(|| prev_rhs.map_or(1, |n| n.as_usize() + 2))
+}
+
 pub(crate) fn print(
     hunks: &[Hunk],
     display_options: &DisplayOptions,
@@ -608,18 +626,6 @@ pub(crate) fn print(
     );
 
     for (i, hunk) in hunks.iter().enumerate() {
-        println!(
-            "{}",
-            style::header(
-                display_path,
-                old_path,
-                i + 1,
-                hunks.len(),
-                file_format,
-                display_options
-            )
-        );
-
         let (start_i, end_i) = matched_lines_indexes_for_hunk(
             matched_lines_to_print,
             hunk,
@@ -632,6 +638,25 @@ pub(crate) fn print(
         // iterations, and this function is hot on large textual
         // diffs.
         matched_lines_to_print = &matched_lines_to_print[start_i..];
+
+        let banner = style::header(
+            display_path,
+            old_path,
+            i + 1,
+            hunks.len(),
+            file_format,
+            display_options,
+        );
+        match &metadata {
+            // The banner announces both the file and this hunk: every banner
+            // carries the hunk's `h` (with the hunk's first new-file line), and
+            // the first hunk's banner additionally carries the file's `f`.
+            Some(metadata) => {
+                let new_line = hunk_first_new_line(aligned_lines, prev_rhs_line_num);
+                println!("{}", metadata.header_banner(i == 0, new_line, &banner));
+            }
+            None => println!("{}", banner),
+        }
 
         let no_lhs_changes = hunk.novel_lhs.is_empty();
         let no_rhs_changes = hunk.novel_rhs.is_empty();

--- a/src/display/side_by_side.rs
+++ b/src/display/side_by_side.rs
@@ -7,6 +7,7 @@ use owo_colors::{OwoColorize, Style};
 
 use crate::constants::Side;
 use crate::display::context::all_matched_lines_filled;
+use crate::display::diff_line_metadata::{row_is_novel, DiffLineMetadata};
 use crate::display::hunks::{matched_lines_indexes_for_hunk, Hunk};
 use crate::display::style::{
     self, apply_colors, apply_line_number_color, color_positions, novel_style, replace_tabs,
@@ -74,6 +75,7 @@ fn display_single_column(
     src_lines: &[String],
     side: Side,
     display_options: &DisplayOptions,
+    metadata: Option<&DiffLineMetadata>,
 ) -> Vec<String> {
     let column_width = format_line_num((src_lines.len() as u32).into()).len();
 
@@ -98,6 +100,9 @@ fn display_single_column(
 
     for (i, line) in src_lines.iter().enumerate() {
         let mut formatted_line = String::with_capacity(line.len());
+        if let Some(metadata) = metadata {
+            formatted_line.push_str(&metadata.single_column_cell(side, i));
+        }
         formatted_line.push_str(
             &format_line_num_padded((i as u32).into(), column_width)
                 .style(style)
@@ -432,6 +437,8 @@ pub(crate) fn print(
     lhs_mps: &[MatchedPos],
     rhs_mps: &[MatchedPos],
 ) {
+    let metadata = DiffLineMetadata::from_env(display_path);
+
     let (lhs_content_max_width, rhs_content_max_width) = visible_content_max_display_width(
         lhs_src,
         rhs_src,
@@ -494,6 +501,7 @@ pub(crate) fn print(
             &rhs_colored_lines,
             Side::Right,
             display_options,
+            metadata.as_ref(),
         ) {
             print!("{}", line);
         }
@@ -513,6 +521,7 @@ pub(crate) fn print(
             &lhs_colored_lines,
             Side::Left,
             display_options,
+            metadata.as_ref(),
         ) {
             print!("{}", line);
         }
@@ -653,6 +662,41 @@ pub(crate) fn print(
                 prev_rhs_line_num,
             );
 
+            // Per-cell diff metadata: the left column carries the old line's
+            // identity, the right column the new line's. The line type is the
+            // row's patch-space type (contents compared -- see row_is_novel),
+            // not the display's token novelty: a row changed only on one side
+            // is still a d/a pair to a host staging by these records. Computed
+            // once for the row (the wrapped-continuation rows below carry none)
+            // and prepended to whichever column(s) the chosen rendering path
+            // actually prints.
+            let (lhs_osc, rhs_osc) = match &metadata {
+                Some(metadata) => {
+                    let row_novel =
+                        row_is_novel(*lhs_line_num, *rhs_line_num, &lhs_lines, &rhs_lines);
+                    (
+                        metadata.left_cell(
+                            *lhs_line_num,
+                            *rhs_line_num,
+                            row_novel,
+                            prev_rhs_line_num,
+                        ),
+                        metadata.right_cell(*rhs_line_num, row_novel),
+                    )
+                }
+                None => (String::new(), String::new()),
+            };
+            // A collapsed (single-column) row prints only one side's content,
+            // but still represents every patch line of the aligned row: a
+            // modification carries its d and its a back-to-back at the row's
+            // start (the first region is zero-width -- spec §6.2). A context
+            // row's two identical records collapse to one.
+            let row_oscs = if lhs_osc == rhs_osc {
+                lhs_osc.clone()
+            } else {
+                format!("{}{}", lhs_osc, rhs_osc)
+            };
+
             let show_both = matches!(
                 display_options.display_mode,
                 DisplayMode::SideBySideShowBoth
@@ -662,11 +706,11 @@ pub(crate) fn print(
                     Some(rhs_line_num) => {
                         let rhs_line = &rhs_colored_lines[rhs_line_num.as_usize()];
                         if same_lines {
-                            print!("{}{}", display_rhs_line_num, rhs_line);
+                            print!("{}{}{}", row_oscs, display_rhs_line_num, rhs_line);
                         } else {
                             print!(
-                                "{}{}{}",
-                                display_lhs_line_num, display_rhs_line_num, rhs_line
+                                "{}{}{}{}",
+                                row_oscs, display_lhs_line_num, display_rhs_line_num, rhs_line
                             );
                         }
                     }
@@ -674,7 +718,10 @@ pub(crate) fn print(
                         // We didn't have any changed RHS lines in the
                         // hunk, but we had some contextual lines that
                         // only occurred on the LHS (e.g. extra newlines).
-                        println!("{}{}", display_lhs_line_num, display_rhs_line_num);
+                        println!(
+                            "{}{}{}",
+                            row_oscs, display_lhs_line_num, display_rhs_line_num
+                        );
                     }
                 }
             } else if no_rhs_changes && !show_both {
@@ -682,16 +729,19 @@ pub(crate) fn print(
                     Some(lhs_line_num) => {
                         let lhs_line = &lhs_colored_lines[lhs_line_num.as_usize()];
                         if same_lines {
-                            print!("{}{}", display_lhs_line_num, lhs_line);
+                            print!("{}{}{}", row_oscs, display_lhs_line_num, lhs_line);
                         } else {
                             print!(
-                                "{}{}{}",
-                                display_lhs_line_num, display_rhs_line_num, lhs_line
+                                "{}{}{}{}",
+                                row_oscs, display_lhs_line_num, display_rhs_line_num, lhs_line
                             );
                         }
                     }
                     None => {
-                        println!("{}{}", display_lhs_line_num, display_rhs_line_num);
+                        println!(
+                            "{}{}{}",
+                            row_oscs, display_lhs_line_num, display_rhs_line_num
+                        );
                     }
                 }
             } else {
@@ -716,13 +766,17 @@ pub(crate) fn print(
                     None => vec!["".into()],
                 };
 
-                for (i, (lhs_line, rhs_line)) in zip_pad_shorter(&lhs_line, &rhs_line)
+                for (i, (lhs_piece, rhs_piece)) in zip_pad_shorter(&lhs_line, &rhs_line)
                     .into_iter()
                     .enumerate()
                 {
-                    let lhs_line = lhs_line
+                    // The shorter side runs out of wrapped pieces first; its
+                    // remaining rows are padding and carry no metadata.
+                    let lhs_has_content = lhs_piece.is_some();
+                    let rhs_has_content = rhs_piece.is_some();
+                    let lhs_line = lhs_piece
                         .unwrap_or_else(|| " ".repeat(source_dims.lhs_content_display_width));
-                    let rhs_line = rhs_line.unwrap_or_else(|| "".into());
+                    let rhs_line = rhs_piece.unwrap_or_else(|| "".into());
                     let lhs_num: String = if i == 0 {
                         display_lhs_line_num.clone()
                     } else {
@@ -766,7 +820,26 @@ pub(crate) fn print(
                         s
                     };
 
-                    println!("{}{}{}{}{}", lhs_num, lhs_line, SPACER, rhs_num, rhs_line);
+                    // difftastic wraps a long line into several output rows
+                    // itself, and a host sees each as a distinct line, so every
+                    // row carries its line's record -- not just the first. This
+                    // lets a host act on a continuation row (open the editor,
+                    // dive into staging) and treat the whole wrapped line as one
+                    // block when navigating, rather than stopping on each row.
+                    let lhs_cell_osc = if lhs_has_content {
+                        lhs_osc.as_str()
+                    } else {
+                        ""
+                    };
+                    let rhs_cell_osc = if rhs_has_content {
+                        rhs_osc.as_str()
+                    } else {
+                        ""
+                    };
+                    println!(
+                        "{}{}{}{}{}{}{}",
+                        lhs_cell_osc, lhs_num, lhs_line, SPACER, rhs_cell_osc, rhs_num, rhs_line
+                    );
                 }
             }
 
@@ -853,6 +926,7 @@ mod tests {
             &["print(123)\n".to_owned()],
             Side::Right,
             &DisplayOptions::default(),
+            None,
         );
         let res = res_lines.join("");
         assert!(res.len() > 10);

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,7 +396,17 @@ fn main() {
             std::process::exit(exit_code);
         }
         Mode::GitHasUnmergedFile { display_path } => {
-            println!("Unmerged path: {display_path}");
+            // The only row announcing this file, so it carries the file's `f`
+            // record -- keeping conflicted files visible to the identity
+            // layer (spec §5.5), like any other file with no content lines.
+            emit_metadata_handshake_once();
+            println!(
+                "{}",
+                display::diff_line_metadata::tag_hunkless_file_banner(
+                    &display_path,
+                    &format!("Unmerged path: {display_path}"),
+                )
+            );
         }
     };
 }
@@ -930,13 +940,16 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
                 if display_options.print_unchanged {
                     println!(
                         "{}",
-                        display::style::header(
+                        display::diff_line_metadata::tag_hunkless_file_banner(
                             &summary.display_path,
-                            summary.extra_info.as_ref(),
-                            1,
-                            1,
-                            &summary.file_format,
-                            display_options
+                            &display::style::header(
+                                &summary.display_path,
+                                summary.extra_info.as_ref(),
+                                1,
+                                1,
+                                &summary.file_format,
+                                display_options
+                            )
                         )
                     );
                     match summary.file_format {
@@ -957,13 +970,16 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
             if summary.has_syntactic_changes && hunks.is_empty() {
                 println!(
                     "{}",
-                    display::style::header(
+                    display::diff_line_metadata::tag_hunkless_file_banner(
                         &summary.display_path,
-                        summary.extra_info.as_ref(),
-                        1,
-                        1,
-                        &summary.file_format,
-                        display_options
+                        &display::style::header(
+                            &summary.display_path,
+                            summary.extra_info.as_ref(),
+                            1,
+                            1,
+                            &summary.file_format,
+                            display_options
+                        )
                     )
                 );
                 match summary.file_format {
@@ -1010,15 +1026,20 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
         }
         (FileContent::Binary, FileContent::Binary) => {
             if display_options.print_unchanged || summary.has_byte_changes.is_some() {
+                // A binary file emits no content records; its `f` keeps it
+                // visible to the identity layer (spec §5.5).
                 println!(
                     "{}",
-                    display::style::header(
+                    display::diff_line_metadata::tag_hunkless_file_banner(
                         &summary.display_path,
-                        summary.extra_info.as_ref(),
-                        1,
-                        1,
-                        &FileFormat::Binary,
-                        display_options
+                        &display::style::header(
+                            &summary.display_path,
+                            summary.extra_info.as_ref(),
+                            1,
+                            1,
+                            &FileFormat::Binary,
+                            display_options
+                        )
                     )
                 );
 
@@ -1060,13 +1081,16 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
             // We're diffing a binary file against a text file.
             println!(
                 "{}",
-                display::style::header(
+                display::diff_line_metadata::tag_hunkless_file_banner(
                     &summary.display_path,
-                    summary.extra_info.as_ref(),
-                    1,
-                    1,
-                    &FileFormat::Binary,
-                    display_options
+                    &display::style::header(
+                        &summary.display_path,
+                        summary.extra_info.as_ref(),
+                        1,
+                        1,
+                        &FileFormat::Binary,
+                        display_options
+                    )
                 )
             );
             println!("Binary contents changed.\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -903,7 +903,25 @@ fn diff_directories<'a>(
     })
 }
 
+/// Emit the diff-metadata handshake (a version-only OSC 1717, see the spec §4.4) once
+/// per run, as difftastic's first output, so a host can probe it — even on an empty
+/// diff, which prints no per-line records. Flushed so it reaches a host that captures
+/// the output, since difftastic exits via `process::exit`, which skips the implicit
+/// flush.
+fn emit_metadata_handshake_once() {
+    use std::io::Write;
+    static EMITTED: std::sync::Once = std::sync::Once::new();
+    EMITTED.call_once(|| {
+        let handshake = display::diff_line_metadata::handshake();
+        if !handshake.is_empty() {
+            print!("{handshake}");
+            let _ = std::io::stdout().flush();
+        }
+    });
+}
+
 fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
+    emit_metadata_handshake_once();
     match (&summary.lhs_src, &summary.rhs_src) {
         (FileContent::Text(lhs_src), FileContent::Text(rhs_src)) => {
             let hunks = &summary.hunks;


### PR DESCRIPTION
This adds support for the OSC-1717 spec described in https://github.com/stefanhaller/diff-line-metadata-spec; see also https://github.com/jesseduffield/lazygit/pull/5732 for more context.

Closes #1004.