### PR TITLE
Track and report position of first parse error

### DIFF
--- a/manual/src/tricky_cases.md
+++ b/manual/src/tricky_cases.md
@@ -497,11 +497,12 @@ parser.
 
 **Difftastic**: Difftastic will fall back to a line-oriented diff if
 any parse errors occur, to avoid diffing incomplete syntax trees. When
-this occurs, the file header reports the error count.
+this occurs, the file header reports the error count along with the
+position of the first parse error.
 
 ```
 $ difft sample_files/syntax_error_1.js sample_files/syntax_error_2.js
-sample_files/syntax_error_2.js --- Text (2 errors, exceeded DFT_PARSE_ERROR_LIMIT)
+sample_files/syntax_error_2.js --- Text (2 JavaScript parse errors, exceeded DFT_PARSE_ERROR_LIMIT, first at 3:1)
 ...
 ```
 

--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -89,7 +89,7 @@ sample_files/hack_1.php sample_files/hack_2.php
 fd23895fca3cb3e70b5ffd364f8c30fe  -
 
 sample_files/hare_1.ha sample_files/hare_2.ha
-e344b3fa7bc35fd4a0f3c7cecab39447  -
+5cffeeeafecc45689c2f43cad6c169e5  -
 
 sample_files/haskell_1.hs sample_files/haskell_2.hs
 3cace65f14319c339fcbd30e8e9ebdcc  -
@@ -155,7 +155,7 @@ sample_files/lua_1.lua sample_files/lua_2.lua
 11693bb34168541f2ac9f4154d246038  -
 
 sample_files/makefile_1.mk sample_files/makefile_2.mk
-87e3b196d26ca6de861e546ee582d929  -
+8c5cc39b6dab819fcc0f472698e21b35  -
 
 sample_files/many_newlines_1.txt sample_files/many_newlines_2.txt
 52ca05855e520876479e6f608c5e7831  -
@@ -272,7 +272,7 @@ sample_files/swift_1.swift sample_files/swift_2.swift
 3a90686a3e172ae19a5fd7cef2f1b944  -
 
 sample_files/syntax_error_1.js sample_files/syntax_error_2.js
-ce571e3438427e83f11a4f4264e1ae30  -
+32c72c64f399bbd26fdffbfed1066789  -
 
 sample_files/tab_1.c sample_files/tab_2.c
 fd896b8e53b183f0d1d5cfeb6a1dfab4  -

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,7 +750,7 @@ fn diff_file_content(
                                 )
                             }
                         }
-                        Err(tsp::ExceededParseErrorLimit(error_count)) => {
+                        Err(tsp::ExceededParseErrorLimit { error_count }) => {
                             let file_format = FileFormat::TextFallback {
                                 reason: format!(
                                     "{} {} parse error{}, exceeded DFT_PARSE_ERROR_LIMIT",

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ use log::info;
 use options::{FilePermissions, USAGE};
 
 use crate::conflicts::{apply_conflict_markers, START_LHS_MARKER};
+use crate::constants::Side;
 use crate::diff::changes::ChangeMap;
 use crate::diff::shortest_path::ExceededGraphLimit;
 use crate::diff::{shortest_path, unchanged};
@@ -750,13 +751,32 @@ fn diff_file_content(
                                 )
                             }
                         }
-                        Err(tsp::ExceededParseErrorLimit { error_count }) => {
+                        Err(tsp::ExceededParseErrorLimit {
+                            error_count,
+                            first_error_pos,
+                        }) => {
+                            let location = match first_error_pos {
+                                Some((line, column, side)) => {
+                                    let in_initial = match side {
+                                        Side::Left => " in initial file",
+                                        Side::Right => "",
+                                    };
+                                    format!(
+                                        ", first at {}:{}{}",
+                                        line.display(),
+                                        column,
+                                        in_initial
+                                    )
+                                }
+                                None => "".to_owned(),
+                            };
                             let file_format = FileFormat::TextFallback {
                                 reason: format!(
-                                    "{} {} parse error{}, exceeded DFT_PARSE_ERROR_LIMIT",
+                                    "{} {} parse error{}, exceeded DFT_PARSE_ERROR_LIMIT{}",
                                     error_count,
                                     language_name(language),
-                                    if error_count == 1 { "" } else { "s" }
+                                    if error_count == 1 { "" } else { "s" },
+                                    location
                                 ),
                             };
 

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -2,12 +2,13 @@
 
 use std::sync::{LazyLock, Mutex};
 
-use line_numbers::LinePositions;
+use line_numbers::{LineNumber, LinePositions};
 use streaming_iterator::StreamingIterator as _;
 use tree_sitter as ts;
 use typed_arena::Arena;
 
 use super::syntax::{self, MatchedPos, StringKind};
+use crate::constants::Side;
 use crate::hash::{DftHashMap, DftHashSet};
 use crate::options::DiffOptions;
 use crate::parse::guess_language as guess;
@@ -1498,6 +1499,10 @@ pub(crate) fn comment_positions(
 pub(crate) struct ExceededParseErrorLimit {
     /// The total number of parse errors found across both inputs.
     pub(crate) error_count: usize,
+    /// The line, zero-indexed column, and side of the first parse
+    /// error, if any. The right-hand side is preferred when both sides
+    /// have errors.
+    pub(crate) first_error_pos: Option<(LineNumber, usize, Side)>,
 }
 
 /// Parse error information accumulated while walking a tree-sitter AST.
@@ -1505,12 +1510,19 @@ pub(crate) struct ExceededParseErrorLimit {
 pub(crate) struct ParseErrors {
     /// The number of error nodes seen.
     count: usize,
+    /// The line and zero-indexed column of the first error node seen,
+    /// if any.
+    first_pos: Option<(LineNumber, usize)>,
 }
 
 impl ParseErrors {
-    /// Record that an error node was seen.
-    fn record(&mut self) {
+    /// Record an error node, remembering the position of the first one.
+    fn record(&mut self, node: &ts::Node) {
         self.count += 1;
+        if self.first_pos.is_none() {
+            let pos = node.start_position();
+            self.first_pos = Some(((pos.row as u32).into(), pos.column));
+        }
     }
 }
 
@@ -1541,7 +1553,18 @@ pub(crate) fn to_syntax_with_limit<'a>(
 
     let error_count = lhs_errors.count + rhs_errors.count;
     if error_count > diff_options.parse_error_limit {
-        return Err(ExceededParseErrorLimit { error_count });
+        // Prefer the right-hand side, since that's the file named in
+        // the header, and only fall back to the left-hand side when the
+        // right has no parse errors.
+        let first_error_pos = match (rhs_errors.first_pos, lhs_errors.first_pos) {
+            (Some((line, column)), _) => Some((line, column, Side::Right)),
+            (None, Some((line, column))) => Some((line, column, Side::Left)),
+            (None, None) => None,
+        };
+        return Err(ExceededParseErrorLimit {
+            error_count,
+            first_error_pos,
+        });
     }
 
     Ok((lhs_nodes, rhs_nodes))
@@ -1571,8 +1594,9 @@ pub(crate) fn to_syntax<'a>(
     let mut cursor = tree.walk();
 
     let mut errors = ParseErrors::default();
-    if cursor.node().is_error() {
-        errors.record();
+    let root_node = cursor.node();
+    if root_node.is_error() {
+        errors.record(&root_node);
     }
 
     // The tree always has a single root, whereas we want nodes for
@@ -1745,7 +1769,7 @@ fn syntax_from_cursor<'a>(
     }
 
     if node.is_error() {
-        errors.record();
+        errors.record(&node);
     }
 
     if config.atom_nodes.contains(node.kind()) || highlights.comment_ids.contains(&node.id()) {

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -1495,7 +1495,10 @@ pub(crate) fn comment_positions(
 }
 
 #[derive(Debug)]
-pub(crate) struct ExceededParseErrorLimit(pub(crate) usize);
+pub(crate) struct ExceededParseErrorLimit {
+    /// The total number of parse errors found across both inputs.
+    pub(crate) error_count: usize,
+}
 
 pub(crate) fn to_syntax_with_limit<'a>(
     lhs_src: &str,
@@ -1524,7 +1527,7 @@ pub(crate) fn to_syntax_with_limit<'a>(
 
     let error_count = lhs_error_count + rhs_error_count;
     if error_count > diff_options.parse_error_limit {
-        return Err(ExceededParseErrorLimit(error_count));
+        return Err(ExceededParseErrorLimit { error_count });
     }
 
     Ok((lhs_nodes, rhs_nodes))

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -1480,7 +1480,7 @@ pub(crate) fn comment_positions(
     let arena = Arena::new();
     let ignore_comments = false;
 
-    let (nodes, _err_count) = to_syntax(tree, src, &arena, config, ignore_comments);
+    let (nodes, _errors) = to_syntax(tree, src, &arena, config, ignore_comments);
     let positions = syntax::comment_positions(&nodes);
 
     positions
@@ -1500,6 +1500,20 @@ pub(crate) struct ExceededParseErrorLimit {
     pub(crate) error_count: usize,
 }
 
+/// Parse error information accumulated while walking a tree-sitter AST.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ParseErrors {
+    /// The number of error nodes seen.
+    count: usize,
+}
+
+impl ParseErrors {
+    /// Record that an error node was seen.
+    fn record(&mut self) {
+        self.count += 1;
+    }
+}
+
 pub(crate) fn to_syntax_with_limit<'a>(
     lhs_src: &str,
     rhs_src: &str,
@@ -1509,14 +1523,14 @@ pub(crate) fn to_syntax_with_limit<'a>(
     config: &TreeSitterConfig,
     diff_options: &DiffOptions,
 ) -> Result<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>), ExceededParseErrorLimit> {
-    let (lhs_nodes, lhs_error_count) = to_syntax(
+    let (lhs_nodes, lhs_errors) = to_syntax(
         lhs_tree,
         lhs_src,
         arena,
         config,
         diff_options.ignore_comments,
     );
-    let (rhs_nodes, rhs_error_count) = to_syntax(
+    let (rhs_nodes, rhs_errors) = to_syntax(
         rhs_tree,
         rhs_src,
         arena,
@@ -1525,7 +1539,7 @@ pub(crate) fn to_syntax_with_limit<'a>(
     );
     syntax::init_all_info(&lhs_nodes, &rhs_nodes);
 
-    let error_count = lhs_error_count + rhs_error_count;
+    let error_count = lhs_errors.count + rhs_errors.count;
     if error_count > diff_options.parse_error_limit {
         return Err(ExceededParseErrorLimit { error_count });
     }
@@ -1539,12 +1553,12 @@ pub(crate) fn to_syntax<'a>(
     arena: &'a Arena<Syntax<'a>>,
     config: &TreeSitterConfig,
     ignore_comments: bool,
-) -> (Vec<&'a Syntax<'a>>, usize) {
+) -> (Vec<&'a Syntax<'a>>, ParseErrors) {
     // Don't return anything on an empty input. Most parsers return a
     // zero-width top-level AST node on empty files, which is
     // confusing and not useful for diffing.
     if src.trim().is_empty() {
-        return (vec![], 0);
+        return (vec![], ParseErrors::default());
     }
 
     let highlights = tree_highlights(tree, src, config);
@@ -1556,9 +1570,9 @@ pub(crate) fn to_syntax<'a>(
     let nl_pos = LinePositions::from(src);
     let mut cursor = tree.walk();
 
-    let mut error_count: usize = 0;
+    let mut errors = ParseErrors::default();
     if cursor.node().is_error() {
-        error_count += 1;
+        errors.record();
     }
 
     // The tree always has a single root, whereas we want nodes for
@@ -1570,13 +1584,13 @@ pub(crate) fn to_syntax<'a>(
         src,
         &nl_pos,
         &mut cursor,
-        &mut error_count,
+        &mut errors,
         config,
         &highlights,
         &subtrees,
         ignore_comments,
     );
-    (nodes, error_count)
+    (nodes, errors)
 }
 
 /// Parse `src` with tree-sitter and convert to difftastic Syntax.
@@ -1587,7 +1601,7 @@ pub(crate) fn parse<'a>(
     ignore_comments: bool,
 ) -> Vec<&'a Syntax<'a>> {
     let tree = to_tree(src, config);
-    let (nodes, _err_count) = to_syntax(&tree, src, arena, config, ignore_comments);
+    let (nodes, _errors) = to_syntax(&tree, src, arena, config, ignore_comments);
     nodes
 }
 
@@ -1656,7 +1670,7 @@ fn all_syntaxes_from_cursor<'a>(
     src: &str,
     nl_pos: &LinePositions,
     cursor: &mut ts::TreeCursor,
-    error_count: &mut usize,
+    errors: &mut ParseErrors,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
     subtrees: &DftHashMap<
@@ -1677,7 +1691,7 @@ fn all_syntaxes_from_cursor<'a>(
             src,
             nl_pos,
             cursor,
-            error_count,
+            errors,
             config,
             highlights,
             subtrees,
@@ -1699,7 +1713,7 @@ fn syntax_from_cursor<'a>(
     src: &str,
     nl_pos: &LinePositions,
     cursor: &mut ts::TreeCursor,
-    error_count: &mut usize,
+    errors: &mut ParseErrors,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
     subtrees: &DftHashMap<
@@ -1722,7 +1736,7 @@ fn syntax_from_cursor<'a>(
             src,
             nl_pos,
             &mut sub_cursor,
-            error_count,
+            errors,
             subconfig,
             subhighlights,
             &DftHashMap::default(),
@@ -1731,7 +1745,7 @@ fn syntax_from_cursor<'a>(
     }
 
     if node.is_error() {
-        *error_count += 1;
+        errors.record();
     }
 
     if config.atom_nodes.contains(node.kind()) || highlights.comment_ids.contains(&node.id()) {
@@ -1752,7 +1766,7 @@ fn syntax_from_cursor<'a>(
             src,
             nl_pos,
             cursor,
-            error_count,
+            errors,
             config,
             highlights,
             subtrees,
@@ -1792,7 +1806,7 @@ fn list_from_cursor<'a>(
     src: &str,
     nl_pos: &LinePositions,
     cursor: &mut ts::TreeCursor,
-    error_count: &mut usize,
+    errors: &mut ParseErrors,
     config: &TreeSitterConfig,
     highlights: &HighlightedNodeIds,
     subtrees: &DftHashMap<
@@ -1855,7 +1869,7 @@ fn list_from_cursor<'a>(
                 src,
                 nl_pos,
                 cursor,
-                error_count,
+                errors,
                 config,
                 highlights,
                 subtrees,
@@ -1870,7 +1884,7 @@ fn list_from_cursor<'a>(
                 src,
                 nl_pos,
                 cursor,
-                error_count,
+                errors,
                 config,
                 highlights,
                 subtrees,
@@ -1885,7 +1899,7 @@ fn list_from_cursor<'a>(
                 src,
                 nl_pos,
                 cursor,
-                error_count,
+                errors,
                 config,
                 highlights,
                 subtrees,


### PR DESCRIPTION
## Summary
Enhanced parse error reporting to include the line and column position of the first parse error encountered, in addition to the total error count. This helps users quickly locate syntax issues in their files.

## Key Changes
- **New `ParseErrors` struct**: Replaces simple `usize` error count with a structured type that tracks both the total error count and the position of the first error node encountered
  - Includes a `record()` method to capture error positions while walking the tree-sitter AST
  - Implements `Default` and `Clone` for convenience

- **Updated `ExceededParseErrorLimit` error type**: Changed from a tuple struct holding just the error count to a struct with named fields:
  - `error_count: usize` - total number of parse errors
  - `first_error_pos: Option<(LineNumber, usize)>` - line number and zero-indexed column of first error

- **Error tracking throughout parsing**: Updated all parsing functions (`to_syntax`, `to_syntax_with_limit`, `syntax_from_cursor`, etc.) to use the new `ParseErrors` struct instead of a simple counter

- **Enhanced user-facing error messages**: When parse error limit is exceeded, the error message now includes the position of the first error (e.g., "first at 5:6")

- **Documentation update**: Updated manual to reflect the new error position reporting in the output example

## Implementation Details
- The `ParseErrors::record()` method only captures the position of the *first* error encountered, avoiding unnecessary overhead for subsequent errors
- Position tracking uses the existing `LineNumber` type from the `line_numbers` crate
- The implementation preserves backward compatibility in the parsing pipeline while enriching error diagnostics

https://claude.ai/code/session_01JmVJsk7qNYW1UQ5Fkz8zGW