### PR TITLE
Account for ASCII control character display width

### DIFF
--- a/src/display/style.rs
+++ b/src/display/style.rs
@@ -133,8 +133,8 @@ fn split_string_by_width(s: &str, max_width: usize, tab_width: usize) -> Vec<(&s
     parts
 }
 
-/// Return a copy of `src` with tabs expanded and ASCII control
-/// characters replaced by caret notation.
+/// Return a copy of `src` with tabs expanded and non-formatting ASCII
+/// control characters replaced by caret notation.
 pub(crate) fn replace_tabs(src: &str, tab_width: usize) -> String {
     let tab_as_spaces = " ".repeat(tab_width);
     let mut result = String::with_capacity(src.len());
@@ -142,7 +142,7 @@ pub(crate) fn replace_tabs(src: &str, tab_width: usize) -> String {
     for ch in src.chars() {
         if ch == '\t' {
             result.push_str(&tab_as_spaces);
-        } else if ch.is_ascii_control() {
+        } else if ch.is_ascii_control() && !matches!(ch, '\n' | '\r' | '\u{1b}') {
             result.push('^');
             result.push(((ch as u8) ^ 0x40) as char);
         } else {
@@ -637,6 +637,14 @@ mod tests {
     #[test]
     fn replace_ascii_control_with_caret_notation() {
         assert_eq!(replace_tabs("a\u{1f}\u{7f}b", TAB_WIDTH), "a^_^?b");
+    }
+
+    #[test]
+    fn preserve_output_formatting_controls() {
+        assert_eq!(
+            replace_tabs("\u{1b}[31mred\u{1b}[0m\r\n", TAB_WIDTH),
+            "\u{1b}[31mred\u{1b}[0m\r\n"
+        );
     }
 
     #[test]

--- a/src/display/style.rs
+++ b/src/display/style.rs
@@ -17,8 +17,8 @@ fn char_display_width(ch: char, tab_width: usize) -> usize {
     if ch == '\t' {
         tab_width
     } else if ch.is_ascii_control() {
-        // Pagers such as less render ASCII control characters using
-        // two-character caret notation (for example, \x1f as ^_).
+        // ASCII control characters are rendered using two-character
+        // caret notation (for example, \x1f as ^_).
         2
     } else {
         ch.width().unwrap_or(0)
@@ -64,8 +64,7 @@ fn substring_by_byte(s: &str, start: usize, end: usize) -> &str {
 }
 
 fn substring_by_byte_replace_tabs(s: &str, start: usize, end: usize, tab_width: usize) -> String {
-    let s = s[start..end].to_string();
-    s.replace('\t', &" ".repeat(tab_width))
+    replace_tabs(&s[start..end], tab_width)
 }
 
 pub(crate) fn width_respecting_tabs(s: &str, tab_width: usize) -> usize {
@@ -134,11 +133,24 @@ fn split_string_by_width(s: &str, max_width: usize, tab_width: usize) -> Vec<(&s
     parts
 }
 
-/// Return a copy of `src` with all the tab characters replaced by
-/// `tab_width` strings.
+/// Return a copy of `src` with tabs expanded and ASCII control
+/// characters replaced by caret notation.
 pub(crate) fn replace_tabs(src: &str, tab_width: usize) -> String {
     let tab_as_spaces = " ".repeat(tab_width);
-    src.replace('\t', &tab_as_spaces)
+    let mut result = String::with_capacity(src.len());
+
+    for ch in src.chars() {
+        if ch == '\t' {
+            result.push_str(&tab_as_spaces);
+        } else if ch.is_ascii_control() {
+            result.push('^');
+            result.push(((ch as u8) ^ 0x40) as char);
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
 }
 
 /// Split `line` (from the source code) into multiple lines of
@@ -620,6 +632,11 @@ mod tests {
             split_string_by_width("a\u{1f}bc", 3, TAB_WIDTH),
             vec![("a\u{1f}", 0), ("bc", 1)]
         );
+    }
+
+    #[test]
+    fn replace_ascii_control_with_caret_notation() {
+        assert_eq!(replace_tabs("a\u{1f}\u{7f}b", TAB_WIDTH), "a^_^?b");
     }
 
     #[test]

--- a/src/display/style.rs
+++ b/src/display/style.rs
@@ -13,6 +13,18 @@ use crate::options::DisplayOptions;
 use crate::parse::syntax::{AtomKind, MatchKind, MatchedPos, StringKind, TokenKind};
 use crate::summary::FileFormat;
 
+fn char_display_width(ch: char, tab_width: usize) -> usize {
+    if ch == '\t' {
+        tab_width
+    } else if ch.is_ascii_control() {
+        // Pagers such as less render ASCII control characters using
+        // two-character caret notation (for example, \x1f as ^_).
+        2
+    } else {
+        ch.width().unwrap_or(0)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum BackgroundColor {
     Dark,
@@ -37,12 +49,7 @@ fn byte_offset_for_width(s: &str, width: usize, tab_width: usize) -> usize {
     for (offset, ch) in s.char_indices() {
         current_offset = offset;
 
-        let char_width = if ch == '\t' {
-            tab_width
-        } else {
-            ch.width().unwrap_or(0)
-        };
-        current_width += char_width;
+        current_width += char_display_width(ch, tab_width);
 
         if current_width > width {
             break;
@@ -70,7 +77,13 @@ pub(crate) fn width_respecting_tabs(s: &str, tab_width: usize) -> usize {
     let tab_count = s.matches('\t').count();
     let tab_display_width_extra = tab_count * tab_width;
 
-    display_width + tab_display_width_extra
+    let ascii_control_count = s
+        .bytes()
+        .filter(|byte| *byte != b'\t' && byte.is_ascii_control())
+        .count();
+    let ascii_control_display_width = ascii_control_count * 2;
+
+    display_width + tab_display_width_extra + ascii_control_display_width
 }
 
 /// Split a string into parts whose display length does not
@@ -598,6 +611,14 @@ mod tests {
         assert_eq!(
             split_string_by_width("ab📦def", 4, TAB_WIDTH),
             vec![("ab📦", 0), ("def", 1)]
+        );
+    }
+
+    #[test]
+    fn split_string_ascii_control() {
+        assert_eq!(
+            split_string_by_width("a\u{1f}bc", 3, TAB_WIDTH),
+            vec![("a\u{1f}", 0), ("bc", 1)]
         );
     }
 


### PR DESCRIPTION
## Summary
  - account for the rendered width of non-tab control characters
  - keep wrapped and side-by-side output aligned
  - add focused regression coverage

  Fixes #569

  ## Testing
  - focused regression test
  - unit and documentation tests
  - cargo fmt --all -- --check

  AI-assisted tooling was used for test development I reviewed and verified every submitted line and can explain the change.