### PR TITLE
Update crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
[RUSTSEC-2026-0204](https://github.com/crossbeam-rs/crossbeam/pull/1276): the `fmt::Pointer` impl for `Atomic` and `Shared` dereferences the underlying pointer, which is invalid for pointers created with `Atomic::null` or `Shared::null`. We reach crossbeam-epoch via rayon.

This is the only unpatched advisory affecting the current lockfile. The change is two lines — a version and a checksum, nothing else bumped.

`cargo test` passes on 1.85.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Emc16itSXoT2wXr3CZmNU)_