### PR TITLE
Support paths starting with a hyphen when git runs difftastic

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -712,9 +712,33 @@ fn parse_binary_overrides_or_die(glob_strs: &[String]) -> Vec<glob::Pattern> {
     overrides
 }
 
+/// The arguments to parse, with `--` inserted if git has invoked us
+/// as an external diff tool.
+///
+/// Git's external diff protocol is entirely positional: it passes 7
+/// arguments (or 9 for a rename) and never passes options. A path
+/// that starts with a hyphen, such as `-foo.txt`, would otherwise
+/// look like an option to us, and git has no way of adding a `--`
+/// separator on our behalf. Without this, git aborts the whole diff
+/// with "fatal: external diff died".
+///
+/// Git sets GIT_DIFF_PATH_TOTAL when running GIT_EXTERNAL_DIFF, so
+/// it's a reliable signal that we're being invoked this way. Note
+/// that `args_os()` includes the name of the binary, so the argument
+/// counts here are one higher.
+fn args_with_git_paths_escaped() -> Vec<OsString> {
+    let mut args: Vec<OsString> = env::args_os().collect();
+
+    if env::var_os("GIT_DIFF_PATH_TOTAL").is_some() && matches!(args.len(), 8 | 10) {
+        args.insert(1, OsString::from("--"));
+    }
+
+    args
+}
+
 /// Parse CLI arguments passed to the binary.
 pub(crate) fn parse_args() -> Mode {
-    let matches = app().get_matches();
+    let matches = app().get_matches_from(args_with_git_paths_escaped());
 
     let color_output = match matches
         .get_one::<String>("color")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -223,6 +223,58 @@ fn git_style_arguments_rename() {
 }
 
 #[test]
+fn git_style_arguments_path_starting_with_hyphen() {
+    let mut cmd = get_base_command();
+
+    // Git passes paths positionally and never passes options, so it
+    // can't use `--` to mark a path that starts with a hyphen.
+    cmd.env("GIT_DIFF_PATH_TOTAL", "1")
+        .arg("-hyphen.el")
+        .arg("sample_files/elisp_1.el")
+        .arg("lhs_hash_placeholder")
+        .arg("lhs_mode_placeholder")
+        .arg("sample_files/elisp_2.el")
+        .arg("rhs_hash_placeholder")
+        .arg("rhs_mode_placeholder");
+
+    let predicate_fn = predicate::str::contains("-hyphen.el");
+    cmd.assert().stdout(predicate_fn);
+}
+
+#[test]
+fn git_style_arguments_rename_to_path_starting_with_hyphen() {
+    let mut cmd = get_base_command();
+
+    cmd.env("GIT_DIFF_PATH_TOTAL", "1")
+        .arg("elisp_oldname.el")
+        .arg("sample_files/elisp_1.el")
+        .arg("lhs_hash_placeholder")
+        .arg("lhs_mode_placeholder")
+        .arg("sample_files/elisp_2.el")
+        .arg("rhs_hash_placeholder")
+        .arg("rhs_mode_placeholder")
+        .arg("-hyphen.el")
+        .arg("similarity_placeholder");
+
+    let predicate_fn = predicate::str::contains("Renamed");
+    cmd.assert().stdout(predicate_fn);
+}
+
+#[test]
+fn options_after_paths() {
+    let mut cmd = get_base_command();
+
+    // Options may be given after the paths, so we can't simply allow
+    // hyphen values on the paths argument.
+    cmd.arg("sample_files/simple_1.js")
+        .arg("sample_files/simple_2.js")
+        .arg("--display=inline");
+
+    let predicate_fn = predicate::str::contains("const React");
+    cmd.assert().success().stdout(predicate_fn);
+}
+
+#[test]
 fn git_style_arguments_new_file() {
     let mut cmd = get_base_command();
 


### PR DESCRIPTION
Fixes difftastic failing on files whose name starts with a hyphen, which currently makes git abort the whole diff.

## The bug

In a repository containing a file named `-dash.js`:

```
$ GIT_EXTERNAL_DIFF=difft git diff
error: unexpected argument '-d' found

  tip: to pass '-d' as a value, use '-- -d'

fatal: external diff died, stopping at -dash.js
```

git exits 128 and stops, so the other files in the diff aren't shown either. Note the error also misidentifies the argument as `-d`, because clap reads `-dash.js` as a cluster of short options.

Git's external diff protocol is entirely positional — it passes 7 arguments (9 for a rename) and never passes options — so there's no way for the caller to add a `--` separator on difftastic's behalf.

## The fix

Insert the `--` separator ourselves when git tells us it's running us as an external diff tool. Git sets `GIT_DIFF_PATH_TOTAL` for `GIT_EXTERNAL_DIFF` invocations, so combined with the 7 or 9 argument count it's an unambiguous signal.

## Why this is gated on the git invocation

`Arg::allow_hyphen_values(true)` on the paths argument would be the obvious alternative, but it's a property of the argument rather than of a calling convention, so it would apply to direct invocations too. clap then treats every later argument beginning with a hyphen as a path without consulting the known options ([`parser.rs:768`](https://github.com/clap-rs/clap/blob/v4.5.23/clap_builder/src/parser/parser.rs#L768)), so `difft old new --display=inline` would become a three-path invocation and error.

Gating on the git signal avoids that, and within the git convention there are no options to lose. Setting `allow_hyphen_values` behind the same gate would work equally well; inserting the separator just keeps the argument definitions untouched.

## Scope

Paths starting with a hyphen still need `--` or a `./` prefix when difftastic is invoked directly (`difft -- -dash.js other.js`). That's consistent with other CLI tools, the workaround is available there, and clap suggests it.

## Testing

Three tests added to `tests/cli.rs`. The two git ones fail on master and pass with this change; `options_after_paths` passes both before and after, and covers options being given after the paths.

Also verified by hand against a real repository — `git diff`, a rename to a hyphen name (the 9 argument form), and deleting a hyphen-named file all now work, and the option handling probes (options before/after paths, attached and detached values, unknown flag typos, `--help`, `--version`, `--list-languages`) behave identically to master.