### PR TITLE
fix(parse): add missing leading * to the .c++ glob

### DIFF
--- a/src/parse/guess_language.rs
+++ b/src/parse/guess_language.rs
@@ -260,7 +260,7 @@ pub(crate) fn language_globs(language: Language) -> Vec<glob::Pattern> {
         // https://madnight.github.io/githut/
         // Also, treating CUDA as C++
         CPlusPlus => &[
-            "*.cc", "*.cpp", ".c++", "*.cxx", "*.cu", "*.h", "*.hh", "*.hpp", "*.hxx", "*.inl",
+            "*.cc", "*.cpp", "*.c++", "*.cxx", "*.cu", "*.h", "*.hh", "*.hpp", "*.hxx", "*.inl",
             "*.ino", "*.ipp", "*.ixx", "*.tcc",
         ],
         CSharp => &["*.cs"],
@@ -645,6 +645,14 @@ mod tests {
     fn test_guess_by_extension() {
         let path = Path::new("foo.el");
         assert_eq!(guess(path, "", &[]), Some(EmacsLisp));
+    }
+
+    #[test]
+    fn test_guess_cplusplus_cplusplus_extension() {
+        // Regression: the `.c++` extension glob was missing its leading `*`
+        // (introduced in 286cad721), so foo.c++ fell through to plain text.
+        let path = Path::new("foo.c++");
+        assert_eq!(guess(path, "", &[]), Some(CPlusPlus));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`foo.c++` was detected as plain text instead of C++ because the `.c++` entry in the C++ file-extension globs was missing its leading `*`, so `glob::Pattern` matched only a literal dotfile named `.c++`, not `foo.c++`.

## Root cause
In `language_globs(CPlusPlus)`, the entry `".c++"` lacks the `*.` prefix every sibling uses (`*.cc`, `*.cpp`, `*.cxx`, ...). A leading `.` in a glob is literal, so the pattern matched only a file literally named `.c++`. A file named `foo.c++` — a legitimate C++ extension recognized by gcc/clang (`-x c++`) and GitHub Linguist — matched no glob, found no shebang/emacs/xml fallback, and fell through to plain-text diffing with no syntax-aware parse.

This was a typo in the commit that added the extension.

## Fix
Add the missing `*` prefix so the entry is `"*.c++"`, matching every other entry in the list.

## Tests
New regression `test_guess_cplusplus_cplusplus_extension` asserts `guess(Path::new("foo.c++"), "", &[]) == Some(CPlusPlus)`.