### PR TITLE
fix: sanitize control characters in diff header and rename message

### DIFF
--- a/src/display/style.rs
+++ b/src/display/style.rs
@@ -536,6 +536,20 @@ pub(crate) fn apply_line_number_color(
     }
 }
 
+/// Replaces control characters (which can include terminal escape
+/// sequences) with the Unicode replacement character. `display_path` and
+/// `extra_info` (a rename message) can originate from a git repository's
+/// tree, e.g. via the GIT_EXTERNAL_DIFF argv, which has no character
+/// restrictions and shouldn't be trusted to display as-is. Applied only
+/// here, at the point of printing, since callers still need the
+/// unmodified path for real filesystem/git operations (gitattributes
+/// lookups, language detection by extension).
+pub(crate) fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
 pub(crate) fn header(
     display_path: &str,
     extra_info: Option<&String>,
@@ -551,7 +565,7 @@ pub(crate) fn header(
     };
 
     let display_path_pretty = apply_header_color(
-        display_path,
+        &sanitize_for_display(display_path),
         display_options.use_color,
         display_options.background_color,
         hunk_num,
@@ -564,7 +578,7 @@ pub(crate) fn header(
 
     match extra_info {
         Some(extra_info) if hunk_num == 1 => {
-            let mut extra_info = extra_info.clone();
+            let mut extra_info = sanitize_for_display(extra_info);
             if display_options.use_color {
                 extra_info = extra_info.dimmed().to_string();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,7 +396,10 @@ fn main() {
             std::process::exit(exit_code);
         }
         Mode::GitHasUnmergedFile { display_path } => {
-            println!("Unmerged path: {display_path}");
+            println!(
+                "Unmerged path: {}",
+                display::style::sanitize_for_display(&display_path)
+            );
         }
     };
 }


### PR DESCRIPTION
Fixes #1033.

`display_path` (and, for renames, the "Renamed from" `extra_info` message) is printed with no filtering of control characters. When difftastic is invoked as git's external diff tool, git passes the diffed file's tracked path directly as a subprocess argument, not as text-quoted output, and a git-tracked filename has no character restrictions. This lets a crafted filename inject terminal escape sequences that get written to the terminal and interpreted live on an ordinary `git diff`.

Adds `sanitize_for_display` (`src/display/style.rs`), replacing control characters with the Unicode replacement character, applied inside `header()` to both `display_path` and `extra_info` (covers every display mode: inline, side-by-side, binary, unchanged/has-changes), plus the one message that bypasses `header()` entirely, `GitHasUnmergedFile`'s "Unmerged path" line in `main.rs`.

I applied this only at the actual print site, not where `display_path` is first parsed from argv. I tried the argv-parsing approach first, but `display_path` also gets used for `git check-attr` gitattributes lookups and language detection by extension, both of which need the unmodified path, and sanitizing that early broke gitattributes detection.

Verified against a git repo with a crafted filename containing a raw OSC title-set sequence, both via a direct `GIT_EXTERNAL_DIFF` invocation and a real `git diff --ext-diff` run, with output redirected to a file and inspected as a hex dump. The injected bytes are replaced, normal file diffs and language detection are unaffected, and the full test suite passes (122 lib tests + 23 CLI integration tests).