### PR TITLE
Check that language configs only use node names that exist

### DIFF
--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -14,7 +14,7 @@ sample_files/all_changed_1.js sample_files/all_changed_2.js
 8b18e5155d4754e8e6d6319be6f58301  -
 
 sample_files/apex_1.cls sample_files/apex_2.cls
-8e477350907734ac4d5201752523dff3  -
+d855a9c09b3c7d76068fd52aea10ca96  -
 
 sample_files/asm_1.s sample_files/asm_2.s
 869f6057e259526eaf913e9505f3d473  -

--- a/sample_files/compare.expected
+++ b/sample_files/compare.expected
@@ -89,7 +89,7 @@ sample_files/hack_1.php sample_files/hack_2.php
 fd23895fca3cb3e70b5ffd364f8c30fe  -
 
 sample_files/haskell_1.hs sample_files/haskell_2.hs
-3cace65f14319c339fcbd30e8e9ebdcc  -
+13b66f32e33046e0cceb1abe5b293aa1  -
 
 sample_files/hcl_1.hcl sample_files/hcl_2.hcl
 b4de7a8269018e05c0eba247d8097111  -

--- a/src/parse/tree_sitter_parser.rs
+++ b/src/parse/tree_sitter_parser.rs
@@ -384,7 +384,7 @@ fn build_config(language: guess::Language) -> TreeSitterConfig {
 
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: vec!["string", "sigil", "heredoc"].into_iter().collect(),
+                atom_nodes: vec!["string", "sigil"].into_iter().collect(),
                 delimiter_tokens: vec![("(", ")"), ("{", "}"), ("do", "end")]
                     .into_iter()
                     .collect(),
@@ -518,7 +518,9 @@ fn build_config(language: guess::Language) -> TreeSitterConfig {
             let language = tree_sitter::Language::new(language_fn);
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["qualified_variable"].into_iter().collect(),
+                // Qualified names, such as Data.List.map. This node
+                // also covers qualified constructors and modules.
+                atom_nodes: ["qualified"].into_iter().collect(),
                 delimiter_tokens: vec![("[", "]"), ("(", ")")],
                 ignore_trailing_tokens: vec![],
                 highlight_query: ts::Query::new(&language, tree_sitter_haskell::HIGHLIGHTS_QUERY)
@@ -717,14 +719,9 @@ fn build_config(language: guess::Language) -> TreeSitterConfig {
                 // structure of complex types within, but it beats
                 // ignoring nullable changes.
                 // https://github.com/Wilfred/difftastic/issues/411
-                atom_nodes: [
-                    "nullable_type",
-                    "string_literal",
-                    "line_string_literal",
-                    "character_literal",
-                ]
-                .into_iter()
-                .collect(),
+                atom_nodes: ["nullable_type", "string_literal", "character_literal"]
+                    .into_iter()
+                    .collect(),
                 delimiter_tokens: vec![("(", ")"), ("{", "}"), ("[", "]"), ("<", ">")]
                     .into_iter()
                     .collect(),
@@ -979,7 +976,7 @@ fn build_config(language: guess::Language) -> TreeSitterConfig {
             let language = tree_sitter::Language::new(language_fn);
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["string", "special"].into_iter().collect(),
+                atom_nodes: ["string"].into_iter().collect(),
                 delimiter_tokens: vec![("{", "}"), ("(", ")"), ("[", "]")],
                 ignore_trailing_tokens: vec![],
                 highlight_query: ts::Query::new(&language, tree_sitter_r::HIGHLIGHTS_QUERY)
@@ -1130,7 +1127,7 @@ fn build_config(language: guess::Language) -> TreeSitterConfig {
             let language = tree_sitter::Language::new(language_fn);
             TreeSitterConfig {
                 language: language.clone(),
-                atom_nodes: ["string", "identifier"].into_iter().collect(),
+                atom_nodes: ["identifier"].into_iter().collect(),
                 delimiter_tokens: vec![("(", ")")],
                 ignore_trailing_tokens: vec![],
                 highlight_query: ts::Query::new(&language, tree_sitter_sequel::HIGHLIGHTS_QUERY)
@@ -2140,5 +2137,60 @@ mod tests {
         for language in guess::Language::iter() {
             from_language(language);
         }
+    }
+
+    /// Check that the node names in language configuration exist in
+    /// the relevant grammar. Names that don't occur in the grammar
+    /// never match, so a typo means the configuration does nothing.
+    ///
+    /// We can't check the token strings in `delimiter_tokens` and
+    /// `ignore_trailing_tokens`, because they're matched against
+    /// source text rather than node names. Grammars sometimes use a
+    /// named node for a delimiter, so a valid token string doesn't
+    /// have to be a node name.
+    #[test]
+    fn test_config_node_names_exist() {
+        let mut problems: Vec<String> = vec![];
+
+        for language in guess::Language::iter() {
+            let config = from_language(language);
+
+            let mut check_node_name = |name: &str, field: &str| {
+                if config.language.id_for_node_kind(name, true) != 0 {
+                    return;
+                }
+
+                // Anonymous tokens are always leaves, so configuring
+                // one is a common mistake.
+                let hint = if config.language.id_for_node_kind(name, false) != 0 {
+                    " (this grammar has an anonymous token with this name, but no named node)"
+                } else {
+                    ""
+                };
+
+                problems.push(format!(
+                    "{:?}: {} refers to the node {:?}, which does not exist in this grammar{}",
+                    language, field, name, hint
+                ));
+            };
+
+            for node_name in &config.atom_nodes {
+                check_node_name(node_name, "atom_nodes");
+            }
+
+            for (node_name, _) in &config.ignore_trailing_tokens {
+                check_node_name(node_name, "ignore_trailing_tokens");
+            }
+        }
+
+        // atom_nodes is a set, so sort for deterministic output.
+        problems.sort();
+
+        assert!(
+            problems.is_empty(),
+            "Found {} node name(s) in language configuration that don't occur in the relevant tree-sitter grammar.\n\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
     }
 }


### PR DESCRIPTION
`atom_nodes` and `ignore_trailing_tokens` refer to tree-sitter node names. Names that don't occur in the grammar never match, so a typo, or a grammar upgrade that renames a node, leaves us with configuration that does nothing — as happened with the Scala `template_string` atom node fixed in #1032.

This adds a test that checks every configured node name against the grammar, using `ts::Language::id_for_node_kind`, and reports all the problems at once:

```
Found 5 node name(s) in language configuration that don't occur in the relevant tree-sitter grammar.

Elixir: atom_nodes refers to the node "heredoc", which does not exist in this grammar
Haskell: atom_nodes refers to the node "qualified_variable", which does not exist in this grammar
Kotlin: atom_nodes refers to the node "line_string_literal", which does not exist in this grammar
R: atom_nodes refers to the node "special", which does not exist in this grammar (this grammar has an anonymous token with this name, but no named node)
Sql: atom_nodes refers to the node "string", which does not exist in this grammar
```

Four of those were doing nothing, and removing them doesn't change any output:

* Elixir `heredoc`: heredocs parse as `string` nodes, which are already configured.
* Kotlin `line_string_literal`: the vendored grammar only has `string_literal`, which is already configured.
* R `special`: now an anonymous token, and tokens are always leaves.
* SQL `string`: tree-sitter-sequel parses string literals as `literal` nodes, which have no children.

Haskell `qualified_variable` is a real regression: the grammar renamed it to `qualified`, so qualified names had stopped being diffed as a single atom. Fixing it is the only output change in the sample files — `W.peek` is now highlighted as one unit rather than as `W` plus `.peek`. Note that `qualified` also covers qualified constructors and modules, which the grammar used to give separate nodes.

### Not covered

The token strings in `delimiter_tokens` and `ignore_trailing_tokens` can't be checked the same way. Those are matched against source text rather than node names, and grammars sometimes use a named node for a delimiter — tree-sitter-hcl parses `${` as a `template_interpolation_start` node, so `"${"` is valid config despite not being any node's name.

A stricter check flags 15 token strings, but most are false positives for that reason. Some of them do look genuinely dead (Asm and Emacs Lisp `{`/`}`, YAML `(`/`)`, HTML `<!--`/`-->`, Objective-C `@(`/`@[`/`@{`), but I couldn't find a way to distinguish those from the valid ones statically, so I've left them alone.

### Unrelated commit

The last commit updates the expected output for `sample_files/apex_*.cls`, which are detected as LaTeX since the glob change in d17f3c9. That commit didn't update `compare.expected`, so the Output Regression Test is currently failing on master. Happy to drop the commit if you'd rather fix it separately.

### Testing

`cargo test` and `sample_files/compare_all.sh` both pass. I also confirmed the test catches the original bug by re-adding Scala's `template_string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fj666ak1oKiKwFan4iYgKu