### PR TITLE
Name the file that has no conflict markers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -533,7 +533,8 @@ fn diff_conflicts_file(
     if conflict_files.num_conflicts == 0 {
         print_error(
             &format!(
-                "Difftastic requires two paths, or a single file with conflict markers {}.\n",
+                "{} does not contain any conflict markers {}. Difftastic requires two paths, or a single file with conflict markers.\n",
+                display_path,
                 if display_options.use_color {
                     START_LHS_MARKER.bold().to_string()
                 } else {

--- a/src/options.rs
+++ b/src/options.rs
@@ -139,9 +139,6 @@ fn app() -> clap::Command {
     after_help.push('.');
 
     Command::new("Difftastic")
-        // Show options in alphabetical order, rather than in
-        // declaration order.
-        .next_display_order(None)
         .override_usage(USAGE)
         .version(env!("CARGO_PKG_VERSION"))
         .long_version(VERSION.as_str())

--- a/src/options.rs
+++ b/src/options.rs
@@ -139,6 +139,9 @@ fn app() -> clap::Command {
     after_help.push('.');
 
     Command::new("Difftastic")
+        // Show options in alphabetical order, rather than in
+        // declaration order.
+        .next_display_order(None)
         .override_usage(USAGE)
         .version(env!("CARGO_PKG_VERSION"))
         .long_version(VERSION.as_str())


### PR DESCRIPTION
Fixes #764 and #830. Two small commits, one each.

*Disclosure per AI_POLICY.md: written with AI assistance (Claude Code). I have read every line of both changes and am accountable for them; happy to discuss any part.*

## #764 — error message on a single file

Before, any single-file invocation gave the same generic message, whether the file had markers or not:

```
$ difft /tmp/no_conflict.rs
error: Difftastic requires two paths, or a single file with conflict markers <<<<<<<.
```

After:

```
error: /tmp/no_conflict.rs does not contain any conflict markers <<<<<<<. Difftastic requires two paths, or a single file with conflict markers.
```

You asked that it "explicitly mention that foo.ts had no conflict markers", so the file is named and the reason stated; the USAGE block below is unchanged.

I checked that this message can't lie about a different failure: a nonexistent path, a directory, and a binary file all exit earlier with their own messages (`No such file`, `Expected a file, got a directory`, `Expected a text file with conflict markers, got a binary file`). Only a text file with zero conflicts reaches this branch. An empty file correctly reports having no markers.

## #830 — sort options in `--help`

`.next_display_order(None)`, so clap sorts alphabetically:

```
before: --context --width --tab-width --display --color --background ...
after:  --background --byte-limit --check-only --color --context --display ...
```

Sorting is within groups, so `DEBUG OPTIONS` remains a separate heading, still last, with its three entries. This affects `--help` only — no shell completions are committed, and `manual/difft.1.md` is hand-maintained and *already* alphabetical, so this actually brings `--help` into agreement with the man page rather than making anything stale. I didn't run `just man`, since nothing there changed.

## Gates

```
cargo build         clean
cargo test          122 passed; 0 failed; 1 ignored
                     23 passed; 0 failed
cargo fmt --check   clean
```

Total diff is 5 insertions, 1 deletion across the two commits.
