### PR TITLE
Underline the changed parts of a renamed path

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -639,6 +639,58 @@ fn build_display_path(lhs_path: &FileArgument, rhs_path: &FileArgument) -> Strin
     }
 }
 
+/// Underline the `/` separated segments that differ between
+/// `old_name` and `new_name`, so it's obvious which part of the path
+/// changed.
+///
+/// Segments are compared from both ends, so renaming
+/// `scripts/foo.ts` to `src/scripts/foo.ts` only underlines `src`.
+fn underline_changed_segments(old_name: &str, new_name: &str, use_color: bool) -> (String, String) {
+    if !use_color {
+        return (old_name.to_owned(), new_name.to_owned());
+    }
+
+    let old_parts: Vec<&str> = old_name.split('/').collect();
+    let new_parts: Vec<&str> = new_name.split('/').collect();
+    let max_common = old_parts.len().min(new_parts.len());
+
+    let prefix_len = old_parts
+        .iter()
+        .zip(new_parts.iter())
+        .take_while(|(old, new)| old == new)
+        .count();
+    let suffix_len = old_parts
+        .iter()
+        .rev()
+        .zip(new_parts.iter().rev())
+        .take_while(|(old, new)| old == new)
+        .count()
+        .min(max_common - prefix_len);
+
+    (
+        underline_middle(&old_parts, prefix_len, suffix_len),
+        underline_middle(&new_parts, prefix_len, suffix_len),
+    )
+}
+
+fn underline_middle(parts: &[&str], prefix_len: usize, suffix_len: usize) -> String {
+    parts
+        .iter()
+        .enumerate()
+        .map(|(i, part)| {
+            if i >= prefix_len && i < parts.len() - suffix_len {
+                // Explicitly disable underline afterwards rather than
+                // resetting all styles, because the header dims this
+                // whole line.
+                format!("\x1b[4m{}\x1b[24m", part)
+            } else {
+                (*part).to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn parse_overrides_or_die(raw_overrides: &[String]) -> Vec<(LanguageOverride, Vec<glob::Pattern>)> {
     let mut overrides: Vec<(LanguageOverride, Vec<glob::Pattern>)> = vec![];
     let mut invalid_syntax = false;
@@ -936,7 +988,9 @@ pub(crate) fn parse_args() -> Mode {
 
             let old_name = old_name.to_string_lossy().to_string();
             let new_name = new_name.to_string_lossy().to_string();
-            let renamed = format!("Renamed from {} to {}", old_name, new_name);
+            let (old_styled, new_styled) =
+                underline_changed_segments(&old_name, &new_name, use_color);
+            let renamed = format!("Renamed from {} to {}", old_styled, new_styled);
 
             (
                 new_name,
@@ -1075,6 +1129,50 @@ mod tests {
     #[test]
     fn test_app() {
         app().debug_assert();
+    }
+
+    #[test]
+    fn test_underline_changed_segments() {
+        // Same directory, different file name.
+        assert_eq!(
+            underline_changed_segments("src/a.rs", "src/b.rs", true),
+            (
+                "src/\x1b[4ma.rs\x1b[24m".to_owned(),
+                "src/\x1b[4mb.rs\x1b[24m".to_owned()
+            )
+        );
+        // Same file name, different directory.
+        assert_eq!(
+            underline_changed_segments("old/a.rs", "new/a.rs", true),
+            (
+                "\x1b[4mold\x1b[24m/a.rs".to_owned(),
+                "\x1b[4mnew\x1b[24m/a.rs".to_owned()
+            )
+        );
+        // Both changed.
+        assert_eq!(
+            underline_changed_segments("old/a.rs", "new/b.rs", true),
+            (
+                "\x1b[4mold\x1b[24m/\x1b[4ma.rs\x1b[24m".to_owned(),
+                "\x1b[4mnew\x1b[24m/\x1b[4mb.rs\x1b[24m".to_owned()
+            )
+        );
+        // A segment added, so nothing changed on the left hand side.
+        assert_eq!(
+            underline_changed_segments("scripts/a.ts", "src/scripts/a.ts", true),
+            (
+                "scripts/a.ts".to_owned(),
+                "\x1b[4msrc\x1b[24m/scripts/a.ts".to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn test_underline_changed_segments_no_color() {
+        assert_eq!(
+            underline_changed_segments("old/a.rs", "new/b.rs", false),
+            ("old/a.rs".to_owned(), "new/b.rs".to_owned())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #963.

*Disclosure per AI_POLICY.md: written with AI assistance (Claude Code). I've read every line and am accountable for it; happy to discuss any part.*

You asked to underline the changed parts of the path in a rename header. This does that, segment by segment on `/`:

```
same dir, new name    Renamed from src/[a.ts] to src/[b.ts]
same name, new dir    Renamed from [old]/a.ts to [new]/a.ts
both changed          Renamed from [old]/[a.ts] to [new]/[b.ts]
extra segment         Renamed from scripts/backup-db.ts to [src]/scripts/backup-db.ts
```

(brackets = underlined). The last one is the case from your issue: the left side is entirely unchanged, so only the added `src` is marked.

## The one design question

`extra_info` is a plain `String`, so underlining meant either embedding codes or changing the type. I kept the `String` and embedded, gated on the already-computed `use_color`. Changing the type would have rippled through `summary.rs`, `main.rs` (~10 sites), `inline.rs`, `side_by_side.rs` and `style.rs` — far more than this issue warrants. As done, exactly one call site changed.

One subtlety worth flagging: `style.rs:569` dims the whole line, so the underline is closed with `\x1b[24m` (underline-off) rather than `\x1b[0m`, which would have killed the dim for the rest of the line. That's also why owo-colors' `Style` wasn't usable here — it emits a full reset.

`--color never` returns the plain strings untouched, verified with `cat -v` for all four shapes and pinned by a test.

```
cargo test         124 passed (unit), 23 passed (integration)
cargo fmt --check  clean
```

Tests cover the four shapes above plus the no-colour case.
