### PR TITLE
Sort the options in --help alphabetically

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -139,6 +139,9 @@ fn app() -> clap::Command {
     after_help.push('.');
 
     Command::new("Difftastic")
+        // Show options in alphabetical order, rather than in
+        // declaration order.
+        .next_display_order(None)
         .override_usage(USAGE)
         .version(env!("CARGO_PKG_VERSION"))
         .long_version(VERSION.as_str())


### PR DESCRIPTION
Split out of #1041, as you asked.

## What's broken

`difft --help` lists options in declaration order, so related flags are scattered and there is no way to scan for one by name.

## The fix

`next_display_order(None)` tells clap to sort them alphabetically. One line, no behaviour change beyond the help output.

## Verification

`cargo build` and `difft --help` show the options sorted. `cargo test` passes.


*Disclosure per AI_POLICY.md: written with AI assistance (Claude Code). I have read every line and am accountable for it; happy to discuss any part.*