### PR TITLE
Document Debian installation in the manual

### DIFF
--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -32,6 +32,12 @@ with `pacman`.
 $ sudo pacman -S difftastic
 ```
 
+If you're a **Debian** user, you can install `difftastic` (with the `difft` command) from the pkg.haus APT archive, after setting the archive up per the instructions on https://pkg.haus.
+
+```
+$ sudo apt install difftastic
+```
+
 If you're a **Nix** user, you can install
 [difftastic](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/text/difftastic/default.nix)
 with `nix-env`.


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying difftastic for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds a Debian entry to the manual's installation page; the package is `difftastic`, the binary `difft`.