### PR TITLE
Report permission-only changes under --skip-unchanged

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -417,6 +417,11 @@ fn diff_file(
 ) -> DiffResult {
     let (lhs_bytes, rhs_bytes) = read_files_or_die(lhs_path, rhs_path, missing_as_empty);
 
+    let has_permission_change = matches!(
+        (lhs_permissions, rhs_permissions),
+        (Some(lhs_perms), Some(rhs_perms)) if lhs_perms != rhs_perms
+    );
+
     let (mut lhs_src, mut rhs_src) = match (
         guess_content(&lhs_bytes, lhs_path, binary_overrides),
         guess_content(&rhs_bytes, rhs_path, binary_overrides),
@@ -441,6 +446,7 @@ fn diff_file(
                 hunks: vec![],
                 has_byte_changes,
                 has_syntactic_changes: false,
+                has_permission_change,
             };
         }
         (ProbableFileKind::Text(lhs_src), ProbableFileKind::Text(rhs_src), _) => (lhs_src, rhs_src),
@@ -495,6 +501,7 @@ fn diff_file(
         display_options,
         diff_options,
         overrides,
+        has_permission_change,
     )
 }
 
@@ -572,6 +579,7 @@ fn diff_conflicts_file(
         display_options,
         diff_options,
         overrides,
+        false,
     )
 }
 
@@ -581,6 +589,7 @@ fn check_only_text(
     extra_info: Option<String>,
     lhs_src: &str,
     rhs_src: &str,
+    has_permission_change: bool,
 ) -> DiffResult {
     let has_byte_changes = if lhs_src == rhs_src {
         None
@@ -599,6 +608,7 @@ fn check_only_text(
         hunks: vec![],
         has_byte_changes,
         has_syntactic_changes: lhs_src != rhs_src,
+        has_permission_change,
     }
 }
 
@@ -612,6 +622,7 @@ fn diff_file_content(
     display_options: &DisplayOptions,
     diff_options: &DiffOptions,
     overrides: &[(LanguageOverride, Vec<glob::Pattern>)],
+    has_permission_change: bool,
 ) -> DiffResult {
     let guess_src = match rhs_path {
         FileArgument::DevNull => &lhs_src,
@@ -640,6 +651,7 @@ fn diff_file_content(
             hunks: vec![],
             has_byte_changes: None,
             has_syntactic_changes: false,
+            has_permission_change,
         };
     }
 
@@ -647,7 +659,14 @@ fn diff_file_content(
         None => {
             let file_format = FileFormat::PlainText;
             if diff_options.check_only {
-                return check_only_text(&file_format, display_path, extra_info, lhs_src, rhs_src);
+                return check_only_text(
+                    &file_format,
+                    display_path,
+                    extra_info,
+                    lhs_src,
+                    rhs_src,
+                    has_permission_change,
+                );
             }
 
             let (lhs_positions, rhs_positions) = line_parser::change_positions(lhs_src, rhs_src);
@@ -687,6 +706,7 @@ fn diff_file_content(
                                     hunks: vec![],
                                     has_byte_changes,
                                     has_syntactic_changes,
+                                    has_permission_change,
                                 };
                             }
 
@@ -787,6 +807,7 @@ fn diff_file_content(
                                     extra_info,
                                     lhs_src,
                                     rhs_src,
+                                    has_permission_change,
                                 );
                             }
 
@@ -812,6 +833,7 @@ fn diff_file_content(
                             extra_info,
                             lhs_src,
                             rhs_src,
+                            has_permission_change,
                         );
                     }
 
@@ -854,6 +876,7 @@ fn diff_file_content(
         hunks,
         has_byte_changes,
         has_syntactic_changes,
+        has_permission_change,
     }
 }
 
@@ -909,7 +932,7 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
             let hunks = &summary.hunks;
 
             if !summary.has_syntactic_changes {
-                if display_options.print_unchanged {
+                if display_options.print_unchanged || summary.has_permission_change {
                     println!(
                         "{}",
                         display::style::header(
@@ -991,7 +1014,10 @@ fn print_diff_result(display_options: &DisplayOptions, summary: &DiffResult) {
             }
         }
         (FileContent::Binary, FileContent::Binary) => {
-            if display_options.print_unchanged || summary.has_byte_changes.is_some() {
+            if display_options.print_unchanged
+                || summary.has_byte_changes.is_some()
+                || summary.has_permission_change
+            {
                 println!(
                     "{}",
                     display::style::header(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1101,6 +1101,7 @@ mod tests {
             &DisplayOptions::default(),
             &DiffOptions::default(),
             &[],
+            false,
         );
 
         assert_eq!(res.lhs_positions, vec![]);

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -50,10 +50,17 @@ pub(crate) struct DiffResult {
     /// number of bytes in each file.
     pub(crate) has_byte_changes: Option<(usize, usize)>,
     pub(crate) has_syntactic_changes: bool,
+    /// The two files differ only (or additionally) in their file-system
+    /// permissions. This is a reportable change in its own right, even when
+    /// the contents are identical (so `--skip-unchanged` must not hide it).
+    pub(crate) has_permission_change: bool,
 }
 
 impl DiffResult {
     pub(crate) fn has_reportable_change(&self) -> bool {
+        if self.has_permission_change {
+            return true;
+        }
         if matches!(self.lhs_src, FileContent::Binary)
             || matches!(self.rhs_src, FileContent::Binary)
         {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -237,6 +237,40 @@ fn git_style_arguments_new_file() {
     cmd.assert().stdout(predicate_fn);
 }
 
+// Regression test for #1028: a permission-only change (identical content) must still be reported
+// under --skip-unchanged, matching plain difft.
+#[test]
+fn skip_unchanged_still_reports_permission_change() {
+    let mut cmd = get_base_command();
+    cmd.arg("--skip-unchanged")
+        .arg("perm_only.txt")
+        .arg("sample_files/simple_1.txt")
+        .arg("lhs_hash_placeholder")
+        .arg("100755")
+        .arg("sample_files/simple_1.txt")
+        .arg("rhs_hash_placeholder")
+        .arg("100644");
+    cmd.assert()
+        .stdout(predicate::str::contains("File permissions changed"));
+}
+
+// Control for #1028: --skip-unchanged must still hide a genuinely unchanged file (same content,
+// same mode) — the fix must not make everything print.
+#[test]
+fn skip_unchanged_still_hides_unchanged_file() {
+    let mut cmd = get_base_command();
+    cmd.arg("--skip-unchanged")
+        .arg("unchanged.txt")
+        .arg("sample_files/simple_1.txt")
+        .arg("lhs_hash_placeholder")
+        .arg("100644")
+        .arg("sample_files/simple_1.txt")
+        .arg("rhs_hash_placeholder")
+        .arg("100644");
+    cmd.assert()
+        .stdout(predicate::str::contains("simple_1").not());
+}
+
 #[test]
 fn drop_different_path_starts() {
     let mut cmd = get_base_command();


### PR DESCRIPTION
  `--skip-unchanged` hid files whose only difference was file permissions, even though plain
  `difft` reports `File permissions changed`:
  
      $ chmod +x foo/foo.txt
      $ difft --skip-unchanged foo/foo.txt bar/foo.txt   # printed nothing (bug)
      $ difft foo/foo.txt bar/foo.txt
      foo.txt --- Text
      File permissions changed from 100755 to 100644.
      No changes.
  
  The skip decision (`DiffResult::has_reportable_change`, and the single-file text/binary print
  gates) considered only syntactic/byte changes, not permission changes. This tracks permission
  changes on `DiffResult` (`has_permission_change`) and treats them as a reportable change.
  
  Verified: a permission-only change is now shown under `--skip-unchanged` (single-file and
  directory), while a genuinely unchanged file is still hidden. Added git-style regression tests for
  both. All existing `tests/cli.rs` tests pass.
  
  Fixes #1028