### PR TITLE
Don't panic when LHS/RHS unchanged positions don't align

### DIFF
--- a/sample_files/issue_1047_after.tsx
+++ b/sample_files/issue_1047_after.tsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react'
+
+interface TagsInputProps {
+    tags: string
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export class TagsInput extends Component<TagsInputProps> {
+    render() {
+        return (
+                    <label className="flex flex-col gap-1.5">
+                        <span className="text-sm font-medium text-[var(--sea-ink-soft)]">
+                            Tags
+                        </span>
+                        <input
+                            type="text"
+                            value={tags}
+                            onChange={(e) => setTags(e.target.value)}
+                            placeholder="nature, sunset, ocean"
+                            className="rounded-xl border border-[var(--line)] bg-white/60 px-3 py-2 text-sm text-[var(--sea-ink)] outline-none focus:border-[var(--lagoon-deep)]"
+                        />
+                    </label>
+        )
+    }
+}

--- a/sample_files/issue_1047_before.tsx
+++ b/sample_files/issue_1047_before.tsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react'
+
+interface TagsInputProps {
+    tags: string
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export class TagsInput extends Component<TagsInputProps> {
+    render() {
+        return (
+            <label className="flex flex-col gap-1.5">
+                <span className="text-sm font-medium text-[var(--sea-ink-soft)]">
+                    Tags{' '}
+                </span>
+                <input
+                    type="text"
+                    value={this.props.tags}
+                    onChange={this.props.onChange}
+                    placeholder="Tags: nature, sunset, ocean"
+                    className="rounded-xl border border-[var(--line)] bg-white/60 px-3 py-2 text-sm text-[var(--sea-ink)] outline-none focus:border-[var(--lagoon-deep)]"
+                />
+            </label>
+        )
+    }
+}

--- a/src/display/hunks.rs
+++ b/src/display/hunks.rs
@@ -514,6 +514,19 @@ fn sorted_novel_positions(
             (None, None) => {
                 break;
             }
+            // One side is exhausted but the other still has a non-novel (unchanged)
+            // position with no counterpart. This can happen on some real inputs where
+            // the LHS/RHS unchanged positions don't line up exactly (see #1047). Rather
+            // than panicking on `unreachable!`, treat the orphaned position as novel so
+            // it is still displayed and the loop makes progress.
+            (Some(lhs_mp), None) => {
+                lhs_novel_section.push(lhs_mp);
+                lhs_iter.next();
+            }
+            (None, Some(rhs_mp)) => {
+                rhs_novel_section.push(rhs_mp);
+                rhs_iter.next();
+            }
             (lhs_mp, rhs_mp) => {
                 unreachable!("Should be impossible: every LHS Unchanged MatchedPos should have a corresponding RHS Unchanged MatchedPos\n  {:?}\n  {:?}", lhs_mp, rhs_mp);
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -237,6 +237,20 @@ fn git_style_arguments_new_file() {
     cmd.assert().stdout(predicate_fn);
 }
 
+// Regression test for #1047: these inputs used to hit an `unreachable!` panic in
+// display/hunks.rs when the LHS/RHS unchanged positions didn't line up exactly. difft must
+// render them without panicking.
+#[test]
+fn issue_1047_no_unreachable_panic() {
+    let mut cmd = get_base_command();
+    cmd.arg("sample_files/issue_1047_before.tsx")
+        .arg("sample_files/issue_1047_after.tsx");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("panicked").not())
+        .stdout(predicate::str::contains("unreachable").not());
+}
+
 #[test]
 fn drop_different_path_starts() {
     let mut cmd = get_base_command();


### PR DESCRIPTION
  On some real inputs (see #1047) the matching loop in `display/hunks.rs` hit an `unreachable!`
  panic — one side's position iterator was exhausted while the other still had a non-novel
  (unchanged) position with no counterpart — so difft aborted with "external diff died".
  
  This handles the exhausted-one-side case explicitly: treat the orphaned position as novel so it's
  still displayed and the loop makes progress, instead of panicking. Added the reported `.tsx`
  inputs as a regression test asserting difft renders them without panicking.
  
  This is a graceful-degradation fix for the crash; the deeper question of *why* the unchanged
  positions occasionally fail to pair up is left for separate investigation — flagging that
  explicitly so a maintainer can decide if they'd prefer a root-cause fix.
  
  Fixes #1047