### PR TITLE
Include the version in release archive filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: difft
+          archive: $bin-$tag-$target
           # Ensure we respect Cargo.lock in release builds, so the
           # released versions match those tested in CI.
           locked: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ include = [
 ]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ version }/difft-{ target }.{ archive-format }"
+pkg-url = "{ repo }/releases/download/{ version }/difft-{ version }-{ target }.{ archive-format }"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"


### PR DESCRIPTION
Release archives are now named `difft-$tag-$target`, e.g. `difft-0.71.0-x86_64-unknown-linux-gnu.tar.gz`, so downloads of different releases no longer collide. The binstall `pkg-url` is updated to match; older releases are unaffected since binstall reads the metadata of the version it installs.

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdSQugkisw5fLWwZGE5GFK